### PR TITLE
Fixed Delete() function

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -624,7 +624,7 @@ func (p *Properties) Delete(key string) {
 	newKeys := []string{}
 	for _, k := range p.k {
 		if k != key {
-			newKeys = append(newKeys, key)
+			newKeys = append(newKeys, k)
 		}
 	}
 	p.k = newKeys

--- a/properties_test.go
+++ b/properties_test.go
@@ -827,6 +827,8 @@ func (s *TestSuite) TestDeleteKey(c *C) {
 	c.Check(len(p.m), Equals, 1)
 	c.Check(len(p.c), Equals, 0)
 	c.Check(len(p.k), Equals, 1)
+	c.Assert(p.k[0], Equals, "second")
+	c.Assert(p.m["second"], Equals, "key")
 }
 
 func (s *TestSuite) TestDeleteUnknownKey(c *C) {


### PR DESCRIPTION
Delete function was creating a new array that contained only the key that was meant for deletion instead of everything else. The tests missed this since there was nothing that was asserting on the contents of the properties after a delete, just the number of items present.