### PR TITLE
Add support for string maps and more complex filtering

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -562,29 +562,28 @@ func (p *Properties) String() string {
 	}
 	return s
 }
+func (p *Properties) FMap(f func(*Properties) interface{}) interface{}{
+	return f(p)
+}
 // Transforms properties to a map - useful when users of library are themselves
 // building a library and do not want inner datastructures be exposed to their clients
 // E.g. `Properties` as a return type in library which is using magiconair Properties is not suitable.
-func (p *Properties) ToMap() (map[string]string, error) {
+func (p *Properties) ToMap() map[string]string {
 	buffer := make(map[string]string)
-	for _, key := range p.Keys() {
-		buffer[key] = p.GetString(key, "")
+	for k,v := range p.m {
+		buffer[k] = v
 	}
-	return buffer, nil
+	return buffer
 }
-
-// Transforms properties to a map but with application of series of filters provided by user
-// See `ToMap` for more simple explanation.
-func (p *Properties) ToMapWithFilters(filters ... func(*Properties) *Properties) (map[string]string, error) {
-	var filteredProperties *Properties
+// Transforms properties to a map - useful when users of library are themselves
+// building a library and do not want inner datastructures be exposed to their clients
+// E.g. `Properties` as a return type in library which is using magiconair Properties is not suitable.
+func (p *Properties) ToMapWith(filters ... func(map[string]string) map[string]string) map[string]string {
+	mapped := p.ToMap()
 	for _, f := range filters {
-		filteredProperties = f(p)
+		mapped = f(mapped)
 	}
-	buffer := make(map[string]string)
-	for _, key := range filteredProperties.Keys() {
-		buffer[key] = filteredProperties.GetString(key, "")
-	}
-	return buffer,nil
+	return mapped
 }
 
 // Write writes all unexpanded 'key = value' pairs to the given writer.

--- a/properties.go
+++ b/properties.go
@@ -563,7 +563,7 @@ func (p *Properties) String() string {
 	return s
 }
 func (p *Properties) FMap(f func(*Properties) interface{}) interface{}{
-	return f(p)
+return f(p)
 }
 // Transforms properties to a map - useful when users of library are themselves
 // building a library and do not want inner datastructures be exposed to their clients

--- a/properties.go
+++ b/properties.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
-	"github.com/magiconair/properties"
 )
 
 // ErrorHandlerFunc defines the type of function which handles failures
@@ -569,23 +568,23 @@ func (p *Properties) String() string {
 func (p *Properties) ToMap() (map[string]string, error) {
 	buffer := make(map[string]string)
 	for _, key := range p.Keys() {
-		buffer[key] = p[key]
+		buffer[key] = p.GetString(key, "")
 	}
-	return buffer
+	return buffer, nil
 }
 
 // Transforms properties to a map but with application of series of filters provided by user
 // See `ToMap` for more simple explanation.
-func (p *Properties) ToMapWithFilters(filters ... func(Properties) Properties) (map[string]string, error) {
-	var filteredProperties properties.Properties
+func (p *Properties) ToMapWithFilters(filters ... func(*Properties) *Properties) (map[string]string, error) {
+	var filteredProperties *Properties
 	for _, f := range filters {
 		filteredProperties = f(p)
 	}
 	buffer := make(map[string]string)
 	for _, key := range filteredProperties.Keys() {
-		buffer[key] = filteredProperties[key]
+		buffer[key] = filteredProperties.GetString(key, "")
 	}
-	return buffer
+	return buffer,nil
 }
 
 // Write writes all unexpanded 'key = value' pairs to the given writer.

--- a/properties.go
+++ b/properties.go
@@ -562,31 +562,6 @@ func (p *Properties) String() string {
 	}
 	return s
 }
-func (p *Properties) FMap(f func(*Properties) interface{}) interface{} {
-	return f(p)
-}
-
-// Transforms properties to a map - useful when users of library are themselves
-// building a library and do not want inner datastructures be exposed to their clients
-// E.g. `Properties` as a return type in library which is using magiconair Properties is not suitable.
-func (p *Properties) ToMap() map[string]string {
-	buffer := make(map[string]string)
-	for k, v := range p.m {
-		buffer[k] = v
-	}
-	return buffer
-}
-
-// Transforms properties to a map - useful when users of library are themselves
-// building a library and do not want inner datastructures be exposed to their clients
-// E.g. `Properties` as a return type in library which is using magiconair Properties is not suitable.
-func (p *Properties) ToMapWith(filters ...func(map[string]string) map[string]string) map[string]string {
-	mapped := p.ToMap()
-	for _, f := range filters {
-		mapped = f(mapped)
-	}
-	return mapped
-}
 
 // Write writes all unexpanded 'key = value' pairs to the given writer.
 // Write returns the number of bytes written and any write error encountered.
@@ -645,6 +620,33 @@ func (p *Properties) WriteComment(w io.Writer, prefix string, enc Encoding) (n i
 		n += x
 	}
 	return
+}
+
+// ToMap returns a copy of the properties as a map - useful when users of library are themselves
+// building a library and do not want inner datastructures be exposed to their clients
+// E.g. `Properties` as a return type in library which is using magiconair Properties is not suitable.
+func (p *Properties) ToMap() map[string]string {
+	m := make(map[string]string)
+	for k, v := range p.m {
+		m[k] = v
+	}
+	return m
+}
+
+/// FilterFunc returns a copy of the properties which includes the values
+// which passed all filters.
+func (p *Properties) FilterFunc(filters ...func(k, v string) bool) *Properties {
+	pp := NewProperties()
+outer:
+	for k, v := range p.m {
+		for _, f := range filters {
+			if !f(k, v) {
+				continue outer
+			}
+			pp.Set(k, v)
+		}
+	}
+	return pp
 }
 
 // ----------------------------------------------------------------------------

--- a/properties.go
+++ b/properties.go
@@ -50,8 +50,8 @@ func PanicHandler(err error) {
 // All values are stored in unexpanded form and are expanded at runtime
 type Properties struct {
 	// Pre-/Postfix for property expansion.
-	Prefix           string
-	Postfix          string
+	Prefix  string
+	Postfix string
 
 	// DisableExpansion controls the expansion of properties on Get()
 	// and the check for circular references on Set(). When set to
@@ -60,13 +60,13 @@ type Properties struct {
 	DisableExpansion bool
 
 	// Stores the key/value pairs
-	m                map[string]string
+	m map[string]string
 
 	// Stores the comments per key.
-	c                map[string][]string
+	c map[string][]string
 
 	// Stores the keys in order of appearance.
-	k                []string
+	k []string
 }
 
 // NewProperties creates a new Properties struct with the default
@@ -98,7 +98,7 @@ func (p *Properties) Get(key string) (value string, ok bool) {
 	// circular references and malformed expressions
 	// so we panic if we still get an error here.
 	if err != nil {
-		ErrorHandler(fmt.Errorf("%s in %q", err, key + " = " + v))
+		ErrorHandler(fmt.Errorf("%s in %q", err, key+" = "+v))
 	}
 
 	return expanded, true
@@ -129,7 +129,7 @@ func (p *Properties) GetComment(key string) string {
 	if !ok || len(comments) == 0 {
 		return ""
 	}
-	return comments[len(comments) - 1]
+	return comments[len(comments)-1]
 }
 
 // ----------------------------------------------------------------------------
@@ -562,23 +562,25 @@ func (p *Properties) String() string {
 	}
 	return s
 }
-func (p *Properties) FMap(f func(*Properties) interface{}) interface{}{
-return f(p)
+func (p *Properties) FMap(f func(*Properties) interface{}) interface{} {
+	return f(p)
 }
+
 // Transforms properties to a map - useful when users of library are themselves
 // building a library and do not want inner datastructures be exposed to their clients
 // E.g. `Properties` as a return type in library which is using magiconair Properties is not suitable.
 func (p *Properties) ToMap() map[string]string {
 	buffer := make(map[string]string)
-	for k,v := range p.m {
+	for k, v := range p.m {
 		buffer[k] = v
 	}
 	return buffer
 }
+
 // Transforms properties to a map - useful when users of library are themselves
 // building a library and do not want inner datastructures be exposed to their clients
 // E.g. `Properties` as a return type in library which is using magiconair Properties is not suitable.
-func (p *Properties) ToMapWith(filters ... func(map[string]string) map[string]string) map[string]string {
+func (p *Properties) ToMapWith(filters ...func(map[string]string) map[string]string) map[string]string {
 	mapped := p.ToMap()
 	for _, f := range filters {
 		mapped = f(mapped)
@@ -669,7 +671,7 @@ func (p *Properties) Merge(other *Properties) {
 		p.c[k] = v
 	}
 
-	outer:
+outer:
 	for _, otherKey := range other.k {
 		for _, key := range p.k {
 			if otherKey == key {
@@ -718,7 +720,7 @@ func expand(s string, keys map[string]bool, prefix, postfix string, values map[s
 	}
 
 	end := keyStart + keyLen + len(postfix) - 1
-	key := s[keyStart : keyStart + keyLen]
+	key := s[keyStart : keyStart+keyLen]
 
 	// fmt.Printf("s:%q pp:%q start:%d end:%d keyStart:%d keyLen:%d key:%q\n", s, prefix + "..." + postfix, start, end, keyStart, keyLen, key)
 
@@ -734,7 +736,7 @@ func expand(s string, keys map[string]bool, prefix, postfix string, values map[s
 	// remember that we've seen the key
 	keys[key] = true
 
-	return expand(s[:start] + val + s[end + 1:], keys, prefix, postfix, values)
+	return expand(s[:start]+val+s[end+1:], keys, prefix, postfix, values)
 }
 
 // encode encodes a UTF-8 string to ISO-8859-1 and escapes some characters.
@@ -765,9 +767,9 @@ func encodeIso(s string, special string) string {
 	var v string
 	for pos := 0; pos < len(s); {
 		switch r, w = utf8.DecodeRuneInString(s[pos:]); {
-		case r < 1 << 8: // single byte rune -> escape special chars only
+		case r < 1<<8: // single byte rune -> escape special chars only
 			v += escape(r, special)
-		case r < 1 << 16: // two byte rune -> unicode literal
+		case r < 1<<16: // two byte rune -> unicode literal
 			v += fmt.Sprintf("\\u%04x", r)
 		default: // more than two bytes per rune -> can't encode
 			v += "?"

--- a/properties_test.go
+++ b/properties_test.go
@@ -825,25 +825,14 @@ func TestMerge(t *testing.T) {
 	assert.Equal(t, p1.MustGet("key"), "another value")
 	assert.Equal(t, p1.GetComment("key"), "another comment")
 }
-
-func TestProperties_ToMap(t *testing.T) {
-	i := "key = value\nkey2 = ghi"
-	input := mustParse(t, i)
-	input.Set("event1", "listener1")
-	input.Set("event2", "listener2")
-	input.Set("event3", "listener3")
-	input.Set("event4", "listener4")
-	otherMap := make(map[string]string)
-	otherMap["event1"] = "listener1"
-	otherMap["event2"] = "listener2"
-	otherMap["event3"] = "listener3"
-	otherMap["event4"] = "listener4"
-	otherMap["key"] = "value"
-	otherMap["key2"] = "ghi"
-	assert.Equal(t, input.ToMap(), otherMap)
+func TestToMap(t *testing.T) {
+	input := "key=value\nabc=def"
+	p := mustParse(t, input)
+	m := map[string]string{"key": "value", "abc": "def"}
+	assert.Equal(t, p.ToMap(), m)
 }
 
-func TestProperties_ToMapWith(t *testing.T) {
+func TestFilterFunc(t *testing.T) {
 	i := "event1 = listener1\nevent2 = listener2"
 	input := mustParse(t, i)
 	input.Set("event3", "listener3")
@@ -851,17 +840,14 @@ func TestProperties_ToMapWith(t *testing.T) {
 	otherMap := make(map[string]string)
 	otherMap["event1"] = "listener1"
 	otherMap["event2"] = "listener2"
-	otherMap["event3"] = "listener3"
-	otherMap["event4"] = "listener4"
-	assert.Equal(t, input.ToMapWith(func(iMap map[string]string) map[string]string {
-		rmap := make(map[string]string)
-		for k, v := range iMap {
-			if k != "key" || k != "key2" {
-				rmap[k] = v
-			}
+	assert.Equal(t, input.FilterFunc(func(k, v string) bool {
+		if k == "event1" || k == "event2" {
+			return true
+		} else {
+			return false
+
 		}
-		return rmap
-	}), otherMap)
+	}).ToMap(), otherMap)
 }
 
 // ----------------------------------------------------------------------------

--- a/properties_test.go
+++ b/properties_test.go
@@ -8,13 +8,14 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"github.com/magiconair/properties/assert"
 	"math"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/magiconair/properties/assert"
 )
 
 var verbose = flag.Bool("verbose", false, "Verbose output")
@@ -461,9 +462,7 @@ func TestMustGet(t *testing.T) {
 	input := "key = value\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGet("key"), "value")
-	assert.Panic(t, func() {
-		p.MustGet("invalid")
-	}, "unknown property: invalid")
+	assert.Panic(t, func() { p.MustGet("invalid") }, "unknown property: invalid")
 }
 
 func TestGetBool(t *testing.T) {
@@ -478,9 +477,7 @@ func TestMustGetBool(t *testing.T) {
 	input := "key = true\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetBool("key"), true)
-	assert.Panic(t, func() {
-		p.MustGetBool("invalid")
-	}, "unknown property: invalid")
+	assert.Panic(t, func() { p.MustGetBool("invalid") }, "unknown property: invalid")
 }
 
 func TestGetDuration(t *testing.T) {
@@ -495,12 +492,8 @@ func TestMustGetDuration(t *testing.T) {
 	input := "key = 123\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetDuration("key"), time.Duration(123))
-	assert.Panic(t, func() {
-		p.MustGetDuration("key2")
-	}, "strconv.ParseInt: parsing.*")
-	assert.Panic(t, func() {
-		p.MustGetDuration("invalid")
-	}, "unknown property: invalid")
+	assert.Panic(t, func() { p.MustGetDuration("key2") }, "strconv.ParseInt: parsing.*")
+	assert.Panic(t, func() { p.MustGetDuration("invalid") }, "unknown property: invalid")
 }
 
 func TestGetParsedDuration(t *testing.T) {
@@ -515,12 +508,8 @@ func TestMustGetParsedDuration(t *testing.T) {
 	input := "key = 123ms\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetParsedDuration("key"), 123*time.Millisecond)
-	assert.Panic(t, func() {
-		p.MustGetParsedDuration("key2")
-	}, "time: invalid duration ghi")
-	assert.Panic(t, func() {
-		p.MustGetParsedDuration("invalid")
-	}, "unknown property: invalid")
+	assert.Panic(t, func() { p.MustGetParsedDuration("key2") }, "time: invalid duration ghi")
+	assert.Panic(t, func() { p.MustGetParsedDuration("invalid") }, "unknown property: invalid")
 }
 
 func TestGetFloat64(t *testing.T) {
@@ -535,12 +524,8 @@ func TestMustGetFloat64(t *testing.T) {
 	input := "key = 123\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetFloat64("key"), float64(123))
-	assert.Panic(t, func() {
-		p.MustGetFloat64("key2")
-	}, "strconv.ParseFloat: parsing.*")
-	assert.Panic(t, func() {
-		p.MustGetFloat64("invalid")
-	}, "unknown property: invalid")
+	assert.Panic(t, func() { p.MustGetFloat64("key2") }, "strconv.ParseFloat: parsing.*")
+	assert.Panic(t, func() { p.MustGetFloat64("invalid") }, "unknown property: invalid")
 }
 
 func TestGetInt(t *testing.T) {
@@ -555,12 +540,8 @@ func TestMustGetInt(t *testing.T) {
 	input := "key = 123\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetInt("key"), int(123))
-	assert.Panic(t, func() {
-		p.MustGetInt("key2")
-	}, "strconv.ParseInt: parsing.*")
-	assert.Panic(t, func() {
-		p.MustGetInt("invalid")
-	}, "unknown property: invalid")
+	assert.Panic(t, func() { p.MustGetInt("key2") }, "strconv.ParseInt: parsing.*")
+	assert.Panic(t, func() { p.MustGetInt("invalid") }, "unknown property: invalid")
 }
 
 func TestGetInt64(t *testing.T) {
@@ -575,12 +556,8 @@ func TestMustGetInt64(t *testing.T) {
 	input := "key = 123\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetInt64("key"), int64(123))
-	assert.Panic(t, func() {
-		p.MustGetInt64("key2")
-	}, "strconv.ParseInt: parsing.*")
-	assert.Panic(t, func() {
-		p.MustGetInt64("invalid")
-	}, "unknown property: invalid")
+	assert.Panic(t, func() { p.MustGetInt64("key2") }, "strconv.ParseInt: parsing.*")
+	assert.Panic(t, func() { p.MustGetInt64("invalid") }, "unknown property: invalid")
 }
 
 func TestGetUint(t *testing.T) {
@@ -595,12 +572,8 @@ func TestMustGetUint(t *testing.T) {
 	input := "key = 123\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetUint("key"), uint(123))
-	assert.Panic(t, func() {
-		p.MustGetUint64("key2")
-	}, "strconv.ParseUint: parsing.*")
-	assert.Panic(t, func() {
-		p.MustGetUint64("invalid")
-	}, "unknown property: invalid")
+	assert.Panic(t, func() { p.MustGetUint64("key2") }, "strconv.ParseUint: parsing.*")
+	assert.Panic(t, func() { p.MustGetUint64("invalid") }, "unknown property: invalid")
 }
 
 func TestGetUint64(t *testing.T) {
@@ -615,12 +588,8 @@ func TestMustGetUint64(t *testing.T) {
 	input := "key = 123\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetUint64("key"), uint64(123))
-	assert.Panic(t, func() {
-		p.MustGetUint64("key2")
-	}, "strconv.ParseUint: parsing.*")
-	assert.Panic(t, func() {
-		p.MustGetUint64("invalid")
-	}, "unknown property: invalid")
+	assert.Panic(t, func() { p.MustGetUint64("key2") }, "strconv.ParseUint: parsing.*")
+	assert.Panic(t, func() { p.MustGetUint64("invalid") }, "unknown property: invalid")
 }
 
 func TestGetString(t *testing.T) {
@@ -635,9 +604,7 @@ func TestMustGetString(t *testing.T) {
 	input := `key = value`
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetString("key"), "value")
-	assert.Panic(t, func() {
-		p.MustGetString("invalid")
-	}, "unknown property: invalid")
+	assert.Panic(t, func() { p.MustGetString("invalid") }, "unknown property: invalid")
 }
 
 func TestComment(t *testing.T) {
@@ -755,9 +722,7 @@ func TestSet(t *testing.T) {
 func TestMustSet(t *testing.T) {
 	input := "key=${key}"
 	p := mustParse(t, input)
-	assert.Panic(t, func() {
-		p.MustSet("key", "${key}")
-	}, "circular reference .*")
+	assert.Panic(t, func() { p.MustSet("key", "${key}") }, "circular reference .*")
 }
 
 func TestWrite(t *testing.T) {
@@ -809,12 +774,8 @@ func TestPanicOn32BitIntOverflow(t *testing.T) {
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetInt64("min"), min)
 	assert.Equal(t, p.MustGetInt64("max"), max)
-	assert.Panic(t, func() {
-		p.MustGetInt("min")
-	}, ".* out of range")
-	assert.Panic(t, func() {
-		p.MustGetInt("max")
-	}, ".* out of range")
+	assert.Panic(t, func() { p.MustGetInt("min") }, ".* out of range")
+	assert.Panic(t, func() { p.MustGetInt("max") }, ".* out of range")
 }
 
 func TestPanicOn32BitUintOverflow(t *testing.T) {
@@ -823,9 +784,7 @@ func TestPanicOn32BitUintOverflow(t *testing.T) {
 	input := fmt.Sprintf("max=%d", max)
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetUint64("max"), max)
-	assert.Panic(t, func() {
-		p.MustGetUint("max")
-	}, ".* out of range")
+	assert.Panic(t, func() { p.MustGetUint("max") }, ".* out of range")
 }
 
 func TestDeleteKey(t *testing.T) {

--- a/properties_test.go
+++ b/properties_test.go
@@ -8,14 +8,13 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"github.com/magiconair/properties/assert"
 	"math"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/magiconair/properties/assert"
 )
 
 var verbose = flag.Bool("verbose", false, "Verbose output")
@@ -462,7 +461,9 @@ func TestMustGet(t *testing.T) {
 	input := "key = value\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGet("key"), "value")
-	assert.Panic(t, func() { p.MustGet("invalid") }, "unknown property: invalid")
+	assert.Panic(t, func() {
+		p.MustGet("invalid")
+	}, "unknown property: invalid")
 }
 
 func TestGetBool(t *testing.T) {
@@ -477,7 +478,9 @@ func TestMustGetBool(t *testing.T) {
 	input := "key = true\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetBool("key"), true)
-	assert.Panic(t, func() { p.MustGetBool("invalid") }, "unknown property: invalid")
+	assert.Panic(t, func() {
+		p.MustGetBool("invalid")
+	}, "unknown property: invalid")
 }
 
 func TestGetDuration(t *testing.T) {
@@ -492,8 +495,12 @@ func TestMustGetDuration(t *testing.T) {
 	input := "key = 123\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetDuration("key"), time.Duration(123))
-	assert.Panic(t, func() { p.MustGetDuration("key2") }, "strconv.ParseInt: parsing.*")
-	assert.Panic(t, func() { p.MustGetDuration("invalid") }, "unknown property: invalid")
+	assert.Panic(t, func() {
+		p.MustGetDuration("key2")
+	}, "strconv.ParseInt: parsing.*")
+	assert.Panic(t, func() {
+		p.MustGetDuration("invalid")
+	}, "unknown property: invalid")
 }
 
 func TestGetParsedDuration(t *testing.T) {
@@ -508,8 +515,12 @@ func TestMustGetParsedDuration(t *testing.T) {
 	input := "key = 123ms\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetParsedDuration("key"), 123*time.Millisecond)
-	assert.Panic(t, func() { p.MustGetParsedDuration("key2") }, "time: invalid duration ghi")
-	assert.Panic(t, func() { p.MustGetParsedDuration("invalid") }, "unknown property: invalid")
+	assert.Panic(t, func() {
+		p.MustGetParsedDuration("key2")
+	}, "time: invalid duration ghi")
+	assert.Panic(t, func() {
+		p.MustGetParsedDuration("invalid")
+	}, "unknown property: invalid")
 }
 
 func TestGetFloat64(t *testing.T) {
@@ -524,8 +535,12 @@ func TestMustGetFloat64(t *testing.T) {
 	input := "key = 123\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetFloat64("key"), float64(123))
-	assert.Panic(t, func() { p.MustGetFloat64("key2") }, "strconv.ParseFloat: parsing.*")
-	assert.Panic(t, func() { p.MustGetFloat64("invalid") }, "unknown property: invalid")
+	assert.Panic(t, func() {
+		p.MustGetFloat64("key2")
+	}, "strconv.ParseFloat: parsing.*")
+	assert.Panic(t, func() {
+		p.MustGetFloat64("invalid")
+	}, "unknown property: invalid")
 }
 
 func TestGetInt(t *testing.T) {
@@ -540,8 +555,12 @@ func TestMustGetInt(t *testing.T) {
 	input := "key = 123\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetInt("key"), int(123))
-	assert.Panic(t, func() { p.MustGetInt("key2") }, "strconv.ParseInt: parsing.*")
-	assert.Panic(t, func() { p.MustGetInt("invalid") }, "unknown property: invalid")
+	assert.Panic(t, func() {
+		p.MustGetInt("key2")
+	}, "strconv.ParseInt: parsing.*")
+	assert.Panic(t, func() {
+		p.MustGetInt("invalid")
+	}, "unknown property: invalid")
 }
 
 func TestGetInt64(t *testing.T) {
@@ -556,8 +575,12 @@ func TestMustGetInt64(t *testing.T) {
 	input := "key = 123\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetInt64("key"), int64(123))
-	assert.Panic(t, func() { p.MustGetInt64("key2") }, "strconv.ParseInt: parsing.*")
-	assert.Panic(t, func() { p.MustGetInt64("invalid") }, "unknown property: invalid")
+	assert.Panic(t, func() {
+		p.MustGetInt64("key2")
+	}, "strconv.ParseInt: parsing.*")
+	assert.Panic(t, func() {
+		p.MustGetInt64("invalid")
+	}, "unknown property: invalid")
 }
 
 func TestGetUint(t *testing.T) {
@@ -572,8 +595,12 @@ func TestMustGetUint(t *testing.T) {
 	input := "key = 123\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetUint("key"), uint(123))
-	assert.Panic(t, func() { p.MustGetUint64("key2") }, "strconv.ParseUint: parsing.*")
-	assert.Panic(t, func() { p.MustGetUint64("invalid") }, "unknown property: invalid")
+	assert.Panic(t, func() {
+		p.MustGetUint64("key2")
+	}, "strconv.ParseUint: parsing.*")
+	assert.Panic(t, func() {
+		p.MustGetUint64("invalid")
+	}, "unknown property: invalid")
 }
 
 func TestGetUint64(t *testing.T) {
@@ -588,8 +615,12 @@ func TestMustGetUint64(t *testing.T) {
 	input := "key = 123\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetUint64("key"), uint64(123))
-	assert.Panic(t, func() { p.MustGetUint64("key2") }, "strconv.ParseUint: parsing.*")
-	assert.Panic(t, func() { p.MustGetUint64("invalid") }, "unknown property: invalid")
+	assert.Panic(t, func() {
+		p.MustGetUint64("key2")
+	}, "strconv.ParseUint: parsing.*")
+	assert.Panic(t, func() {
+		p.MustGetUint64("invalid")
+	}, "unknown property: invalid")
 }
 
 func TestGetString(t *testing.T) {
@@ -604,7 +635,9 @@ func TestMustGetString(t *testing.T) {
 	input := `key = value`
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetString("key"), "value")
-	assert.Panic(t, func() { p.MustGetString("invalid") }, "unknown property: invalid")
+	assert.Panic(t, func() {
+		p.MustGetString("invalid")
+	}, "unknown property: invalid")
 }
 
 func TestComment(t *testing.T) {
@@ -722,7 +755,9 @@ func TestSet(t *testing.T) {
 func TestMustSet(t *testing.T) {
 	input := "key=${key}"
 	p := mustParse(t, input)
-	assert.Panic(t, func() { p.MustSet("key", "${key}") }, "circular reference .*")
+	assert.Panic(t, func() {
+		p.MustSet("key", "${key}")
+	}, "circular reference .*")
 }
 
 func TestWrite(t *testing.T) {
@@ -774,8 +809,12 @@ func TestPanicOn32BitIntOverflow(t *testing.T) {
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetInt64("min"), min)
 	assert.Equal(t, p.MustGetInt64("max"), max)
-	assert.Panic(t, func() { p.MustGetInt("min") }, ".* out of range")
-	assert.Panic(t, func() { p.MustGetInt("max") }, ".* out of range")
+	assert.Panic(t, func() {
+		p.MustGetInt("min")
+	}, ".* out of range")
+	assert.Panic(t, func() {
+		p.MustGetInt("max")
+	}, ".* out of range")
 }
 
 func TestPanicOn32BitUintOverflow(t *testing.T) {
@@ -784,7 +823,9 @@ func TestPanicOn32BitUintOverflow(t *testing.T) {
 	input := fmt.Sprintf("max=%d", max)
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetUint64("max"), max)
-	assert.Panic(t, func() { p.MustGetUint("max") }, ".* out of range")
+	assert.Panic(t, func() {
+		p.MustGetUint("max")
+	}, ".* out of range")
 }
 
 func TestDeleteKey(t *testing.T) {
@@ -824,6 +865,44 @@ func TestMerge(t *testing.T) {
 	assert.Equal(t, len(p1.k), 3)
 	assert.Equal(t, p1.MustGet("key"), "another value")
 	assert.Equal(t, p1.GetComment("key"), "another comment")
+}
+
+func TestProperties_ToMap(t *testing.T) {
+	i := "key = value\nkey2 = ghi"
+	input := mustParse(t, i)
+	input.Set("event1", "listener1")
+	input.Set("event2", "listener2")
+	input.Set("event3", "listener3")
+	input.Set("event4", "listener4")
+	otherMap := make(map[string]string)
+	otherMap["event1"] = "listener1"
+	otherMap["event2"] = "listener2"
+	otherMap["event3"] = "listener3"
+	otherMap["event4"] = "listener4"
+	otherMap["key"] = "value"
+	otherMap["key2"] = "ghi"
+	assert.Equal(t, input.ToMap(), otherMap)
+}
+
+func TestProperties_ToMapWith(t *testing.T) {
+	i := "event1 = listener1\nevent2 = listener2"
+	input := mustParse(t, i)
+	input.Set("event3", "listener3")
+	input.Set("event4", "listener4")
+	otherMap := make(map[string]string)
+	otherMap["event1"] = "listener1"
+	otherMap["event2"] = "listener2"
+	otherMap["event3"] = "listener3"
+	otherMap["event4"] = "listener4"
+	assert.Equal(t, input.ToMapWith(func(iMap map[string]string) map[string]string {
+		rmap := make(map[string]string)
+		for k, v := range iMap {
+			if k != "key" || k != "key2" {
+				rmap[k] = v
+			}
+		}
+		return rmap
+	}), otherMap)
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Summary -

Added a simple ToMap, ToMapWith & a general FMap -

ToMap( ) - Allows users to transform properties to a generic map data type this allows library creators using magiconair properties library to be used seamlessly without exposing its own data structures to other projects.

ToMapWith allows additional filter closures that may run apart from ToMap to filter out certain properties along with returning a map.

FMap - allows a generic transformer to transform a properties type to any custom data type as needed using a first order function passed in.