### PR TITLE
Update keys when DisableExpansion is enabled

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -511,6 +511,9 @@ func (p *Properties) Set(key, value string) (prev string, ok bool, err error) {
 	if p.DisableExpansion {
 		prev, ok = p.Get(key)
 		p.m[key] = value
+		if !ok {
+			p.k = append(p.k, key)
+		}
 		return prev, ok, nil
 	}
 

--- a/properties_test.go
+++ b/properties_test.go
@@ -458,6 +458,15 @@ func TestDisableExpansion(t *testing.T) {
 	assert.Equal(t, p.MustGet("keyB"), "${keyA}")
 }
 
+func TestDisableExpansionDoesntBreakSet(t *testing.T) {
+	p := NewProperties()
+	p.MustSet("p1", "a")
+	p.DisableExpansion = true
+	p.MustSet("p2", "b")
+
+	assert.Equal(t, p.String(), "p1 = a\np2 = b\n")
+}
+
 func TestMustGet(t *testing.T) {
 	input := "key = value\nkey2 = ghi"
 	p := mustParse(t, input)


### PR DESCRIPTION
I noticed that when a property added after the expansion is disabled, it is missed in the full printout by `String()`