### PR TITLE
Issue #23: ignore blank lines with only whitespace

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -196,9 +196,8 @@ func lexBeforeKey(l *lexer) stateFn {
 		return lexComment
 
 	case isWhitespace(r):
-		l.acceptRun(whitespace)
 		l.ignore()
-		return lexKey
+		return lexBeforeKey
 
 	default:
 		l.backup()

--- a/properties_test.go
+++ b/properties_test.go
@@ -44,6 +44,8 @@ var complexTests = [][]string{
 	{"\nkey=value\n", "key", "value"},
 	{"\rkey=value\r", "key", "value"},
 	{"\r\nkey=value\r\n", "key", "value"},
+	{"\nkey=value\n \nkey2=value2", "key", "value", "key2", "value2"},
+	{"\nkey=value\n\t\nkey2=value2", "key", "value", "key2", "value2"},
 
 	// escaped chars in key
 	{"k\\ ey = value", "k ey", "value"},


### PR DESCRIPTION
This patch changes the parser so that it will ignore blank lines
which contain only whitespace.

Fixes #23