### PR TITLE
Rework expansion logic

### DIFF
--- a/load.go
+++ b/load.go
@@ -218,7 +218,7 @@ func must(p *Properties, err error) *Properties {
 // with an empty string. Malformed expressions like "${ENV_VAR" will
 // be reported as error.
 func expandName(name string) (string, error) {
-	return expand("", name, make(map[string]bool), "${", "}", make(map[string]string))
+	return expand(name, []string{}, "${", "}", make(map[string]string))
 }
 
 // Interprets a byte buffer either as an ISO-8859-1 or UTF-8 encoded string.

--- a/properties_test.go
+++ b/properties_test.go
@@ -91,6 +91,9 @@ var complexTests = [][]string{
 	{"key=value\nkey2=aa${key}bb", "key", "value", "key2", "aavaluebb"},
 	{"key=value\nkey2=${key}\nkey3=${key2}", "key", "value", "key2", "value", "key3", "value"},
 	{"key=value\nkey2=${key}${key}", "key", "value", "key2", "valuevalue"},
+	{"key=value\nkey2=${key}${key}${key}${key}", "key", "value", "key2", "valuevaluevaluevalue"},
+	{"key=value\nkey2=${key}${key3}\nkey3=${key}", "key", "value", "key2", "valuevalue", "key3", "value"},
+	{"key=value\nkey2=${key3}${key}${key4}\nkey3=${key}\nkey4=${key}", "key", "value", "key2", "valuevaluevalue", "key3", "value", "key4", "value"},
 	{"key=${USER}", "key", os.Getenv("USER")},
 	{"key=${USER}\nUSER=value", "key", "value", "USER", "value"},
 }
@@ -445,6 +448,30 @@ func TestErrors(t *testing.T) {
 		assert.Equal(t, err != nil, true, "want error")
 		assert.Equal(t, strings.Contains(err.Error(), test.msg), true)
 	}
+}
+
+func TestVeryDeep(t *testing.T) {
+	input := "key0=value\n"
+	prefix := "${"
+	postfix := "}"
+	i := 0
+	for i = 0; i < maxExpansionDepth-1; i++ {
+		input += fmt.Sprintf("key%d=%skey%d%s\n", i+1, prefix, i, postfix)
+	}
+
+	p, err := Load([]byte(input), ISO_8859_1)
+	assert.Equal(t, err, nil)
+	p.Prefix = prefix
+	p.Postfix = postfix
+
+	assert.Equal(t, p.MustGet(fmt.Sprintf("key%d", i)), "value")
+
+	// Nudge input over the edge
+	input += fmt.Sprintf("key%d=%skey%d%s\n", i+1, prefix, i, postfix)
+
+	_, err = Load([]byte(input), ISO_8859_1)
+	assert.Equal(t, err != nil, true, "want error")
+	assert.Equal(t, strings.Contains(err.Error(), "expansion too deep"), true)
 }
 
 func TestDisableExpansion(t *testing.T) {


### PR DESCRIPTION
The previous logic would have some bugs if you had a tree like this:

    key = value
    a   = ${b} ${key} ${c}
    b   = ${key}
    c   = ${key}

This reworks the expand() logic to use a stack which is copied at each
level of recursion. This also fixes bugs when you have more than two
expansions, like this:

    a = b
    c = ${a}${a}${a}