### PR TITLE
Add environment variable overrides for file loaded properties

### DIFF
--- a/load.go
+++ b/load.go
@@ -101,6 +101,33 @@ func MustLoadFiles(filenames []string, enc Encoding, ignoreMissing bool) *Proper
 	return must(LoadFiles(filenames, enc, ignoreMissing))
 }
 
+// MustLoadFilesWithEnvOverrides reads multiple files in the given order
+// into a Properties struct and panics on error. If 'ignoreMissing' is
+// true then non-existent files will not be reported as error. After loading
+// MustLoadFilesWithEnvOverrides checks for environment variables in the pattern
+// {envPrefix}SOME_NAME=val and converts the key to a property name by substituting
+// the _ for dots and removing the envPrefix. If this converted key matches any of
+// the loaded properties from the files, it will override the value of the file
+// loaded property with the value of the environment variable.
+func MustLoadFilesWithEnvOverrides(filenames []string, enc Encoding, ignoreMissing bool, envPrefix string) *Properties {
+	propsFromFile := MustLoadFiles(filenames, enc, ignoreMissing)
+
+	for _, e := range os.Environ() {
+		pair := strings.Split(e, "=")
+		key := pair[0]
+		if envPrefix != "" && strings.HasPrefix(key, envPrefix) {
+			envToPropertyName := strings.ToLower(strings.Replace(key[3:], "_", ".", -1))
+			environmentVariableValue := os.Getenv(key)
+
+			envToPropertyName = findOriginalKeyRegardlessOfCase(envToPropertyName, propsFromFile)
+
+			propsFromFile.MustSet(envToPropertyName, environmentVariableValue)
+		}
+	}
+
+	return propsFromFile
+}
+
 // MustLoadURL reads the content of a URL into a Properties struct and
 // panics on error.
 func MustLoadURL(url string) *Properties {
@@ -211,6 +238,15 @@ func must(p *Properties, err error) *Properties {
 		ErrorHandler(err)
 	}
 	return p
+}
+
+func findOriginalKeyRegardlessOfCase(key string, props *Properties) string {
+	for _, origKey := range props.Keys() {
+		if strings.EqualFold(origKey, key) {
+			return origKey
+		}
+	}
+	return key
 }
 
 // expandName expands ${ENV_VAR} expressions in a name.

--- a/load.go
+++ b/load.go
@@ -121,6 +121,7 @@ func MustLoadFilesWithEnvOverrides(filenames []string, enc Encoding, ignoreMissi
 
 			envToPropertyName = findOriginalKeyRegardlessOfCase(envToPropertyName, propsFromFile)
 
+			LogPrintf("Overriding property %s with environment variable %s", envToPropertyName, key)
 			propsFromFile.MustSet(envToPropertyName, environmentVariableValue)
 		}
 	}

--- a/load_test.go
+++ b/load_test.go
@@ -70,6 +70,25 @@ func TestLoadFiles(t *testing.T) {
 	assertKeyValues(t, "", p, "key", "value", "key2", "value2")
 }
 
+func TestLoadFilesWithEnvOverride(t *testing.T) {
+	tf := make(tempFiles, 0)
+	defer tf.removeAll()
+
+	filename := tf.makeFile("thrift.client=proxy")
+	filename2 := tf.makeFile("thrift.MyCamelCase=true")
+
+	os.Setenv("MP_THRIFT_CLIENT", "chicken")
+	os.Setenv("MP_THRIFT_MYCAMELCASE", "false")
+	defer os.Unsetenv("MP_THRIFT_CLIENT")
+	defer os.Unsetenv("MP_THRIFT_MYCAMELCASE")
+
+	p := MustLoadFilesWithEnvOverrides([]string{filename, filename2}, ISO_8859_1, false, "MP_")
+	assertKeyValues(t, "", p, "thrift.client", "chicken", "thrift.MyCamelCase", "false")
+
+	p = MustLoadFilesWithEnvOverrides([]string{filename, filename2}, ISO_8859_1, false, "")
+	assertKeyValues(t, "", p, "thrift.client", "proxy", "thrift.MyCamelCase", "true")
+}
+
 func TestLoadExpandedFile(t *testing.T) {
 	tf := make(tempFiles, 0)
 	defer tf.removeAll()


### PR DESCRIPTION
We internally use the functionality of overriding loaded properties with prefixed environment variables.
We convert the names of these env variables to property keys with a simple replacement scheme. This PR implements this logic. Feel free to do anything with it you like, just sharing in case there is any interest in this approach.

Example:
`thrift.client=proxy`
can be overridden with the
`PREFIX_THRIFT_CLIENT` environment variable, where `PREFIX` is configurable.