### PR TITLE
Refactor loading

### DIFF
--- a/load.go
+++ b/load.go
@@ -149,12 +149,14 @@ func (l *Loader) LoadURL(url string) (*Properties, error) {
 
 // Load reads a buffer into a Properties struct.
 func Load(buf []byte, enc Encoding) (*Properties, error) {
-	return loadBuf(buf, enc, false)
+	l := &Loader{Encoding: enc}
+	return l.LoadBytes(buf)
 }
 
 // LoadString reads an UTF8 string into a properties struct.
 func LoadString(s string) (*Properties, error) {
-	return loadBuf([]byte(s), UTF8, false)
+	l := &Loader{Encoding: UTF8}
+	return l.LoadBytes([]byte(s))
 }
 
 // LoadMap creates a new Properties struct from a string map.
@@ -168,20 +170,23 @@ func LoadMap(m map[string]string) *Properties {
 
 // LoadFile reads a file into a Properties struct.
 func LoadFile(filename string, enc Encoding) (*Properties, error) {
-	return loadAll([]string{filename}, enc, false, false)
+	l := &Loader{Encoding: enc}
+	return l.LoadAll([]string{filename})
 }
 
 // LoadFiles reads multiple files in the given order into
 // a Properties struct. If 'ignoreMissing' is true then
 // non-existent files will not be reported as error.
 func LoadFiles(filenames []string, enc Encoding, ignoreMissing bool) (*Properties, error) {
-	return loadAll(filenames, enc, ignoreMissing, false)
+	l := &Loader{Encoding: enc, IgnoreMissing: ignoreMissing}
+	return l.LoadAll(filenames)
 }
 
 // LoadURL reads the content of the URL into a Properties struct.
 // See Loader#LoadURL for details.
 func LoadURL(url string) (*Properties, error) {
-	return loadAll([]string{url}, UTF8, false, false)
+	l := &Loader{Encoding: UTF8}
+	return l.LoadAll([]string{url})
 }
 
 // LoadURLs reads the content of multiple URLs in the given order into a
@@ -189,7 +194,8 @@ func LoadURL(url string) (*Properties, error) {
 // not be reported as error. See Loader#LoadURL for the Content-Type header
 // and the encoding.
 func LoadURLs(urls []string, ignoreMissing bool) (*Properties, error) {
-	return loadAll(urls, UTF8, ignoreMissing, false)
+	l := &Loader{Encoding: UTF8, IgnoreMissing: ignoreMissing}
+	return l.LoadAll(urls)
 }
 
 // LoadAll reads the content of multiple URLs or files in the given order into a
@@ -197,7 +203,8 @@ func LoadURLs(urls []string, ignoreMissing bool) (*Properties, error) {
 // not be reported as error. Encoding sets the encoding for files. For the URLs please see
 // LoadURL for the Content-Type header and the encoding.
 func LoadAll(names []string, enc Encoding, ignoreMissing bool) (*Properties, error) {
-	return loadAll(names, enc, ignoreMissing, false)
+	l := &Loader{Encoding: enc, IgnoreMissing: ignoreMissing}
+	return l.LoadAll(names)
 }
 
 // MustLoadString reads an UTF8 string into a Properties struct and
@@ -238,26 +245,6 @@ func MustLoadURLs(urls []string, ignoreMissing bool) *Properties {
 // LoadURL for the Content-Type header and the encoding. It panics on error.
 func MustLoadAll(names []string, enc Encoding, ignoreMissing bool) *Properties {
 	return must(LoadAll(names, enc, ignoreMissing))
-}
-
-func loadBuf(buf []byte, enc Encoding, disableExpansion bool) (*Properties, error) {
-	l := &Loader{Encoding: enc, DisableExpansion: disableExpansion}
-	return l.LoadBytes(buf)
-}
-
-func loadAll(names []string, enc Encoding, ignoreMissing, disableExpansion bool) (*Properties, error) {
-	l := &Loader{Encoding: enc, DisableExpansion: disableExpansion, IgnoreMissing: ignoreMissing}
-	return l.LoadAll(names)
-}
-
-func loadFile(filename string, enc Encoding, ignoreMissing bool) (*Properties, error) {
-	l := &Loader{Encoding: enc, IgnoreMissing: ignoreMissing}
-	return l.LoadFile(filename)
-}
-
-func loadURL(url string, ignoreMissing bool) (*Properties, error) {
-	l := &Loader{IgnoreMissing: ignoreMissing}
-	return l.LoadURL(url)
 }
 
 func must(p *Properties, err error) *Properties {

--- a/load.go
+++ b/load.go
@@ -52,7 +52,7 @@ func (l *Loader) LoadBytes(buf []byte) (*Properties, error) {
 // files. For the URLs see LoadURL for the Content-Type header and the
 // encoding.
 func (l *Loader) LoadAll(names []string) (*Properties, error) {
-	result := NewProperties()
+	all := NewProperties()
 	for _, name := range names {
 		n, err := expandName(name)
 		if err != nil {
@@ -71,14 +71,14 @@ func (l *Loader) LoadAll(names []string) (*Properties, error) {
 		if err != nil {
 			return nil, err
 		}
-		result.Merge(p)
+		all.Merge(p)
 	}
 
-	result.DisableExpansion = l.DisableExpansion
-	if result.DisableExpansion {
-		return result, nil
+	all.DisableExpansion = l.DisableExpansion
+	if all.DisableExpansion {
+		return all, nil
 	}
-	return result, result.check()
+	return all, all.check()
 }
 
 // LoadFile reads a file into a Properties struct.

--- a/load.go
+++ b/load.go
@@ -27,7 +27,6 @@ type Loader struct {
 	Encoding         Encoding
 	DisableExpansion bool
 	IgnoreMissing    bool
-	ErrorHandler     func(error)
 }
 
 func (l *Loader) LoadBytes(buf []byte) (*Properties, error) {

--- a/load.go
+++ b/load.go
@@ -60,9 +60,12 @@ func (l *Loader) LoadAll(names []string) (*Properties, error) {
 		}
 
 		var p *Properties
-		if strings.HasPrefix(n, "http://") || strings.HasPrefix(n, "https://") {
+		switch {
+		case strings.HasPrefix(n, "http://"):
 			p, err = l.LoadURL(n)
-		} else {
+		case strings.HasPrefix(n, "https://"):
+			p, err = l.LoadURL(n)
+		default:
 			p, err = l.LoadFile(n)
 		}
 		if err != nil {

--- a/load.go
+++ b/load.go
@@ -120,9 +120,7 @@ func (l *Loader) LoadURL(url string) (*Properties, error) {
 	if err != nil {
 		return nil, fmt.Errorf("properties: %s error reading response. %s", url, err)
 	}
-	if err = resp.Body.Close(); err != nil {
-		return nil, fmt.Errorf("properties: %s error reading response. %s", url, err)
-	}
+	defer resp.Body.Close()
 
 	ct := resp.Header.Get("Content-Type")
 	var enc Encoding

--- a/load.go
+++ b/load.go
@@ -16,8 +16,14 @@ import (
 type Encoding uint
 
 const (
+	// utf8Default is a private placeholder for the zero value of Encoding to
+	// ensure that it has the correct meaning. UTF8 is the default encoding but
+	// was assigned a non-zero value which cannot be changed without breaking
+	// existing code. Clients should continue to use the public constants.
+	utf8Default Encoding = iota
+
 	// UTF8 interprets the input data as UTF-8.
-	UTF8 Encoding = 1 << iota
+	UTF8
 
 	// ISO_8859_1 interprets the input data as ISO-8859-1.
 	ISO_8859_1
@@ -271,7 +277,7 @@ func expandName(name string) (string, error) {
 // first 256 unicode code points cover ISO-8859-1.
 func convert(buf []byte, enc Encoding) string {
 	switch enc {
-	case UTF8:
+	case utf8Default, UTF8:
 		return string(buf)
 	case ISO_8859_1:
 		runes := make([]rune, len(buf))

--- a/load_test.go
+++ b/load_test.go
@@ -16,6 +16,18 @@ import (
 	"github.com/magiconair/properties/assert"
 )
 
+func TestEncoding(t *testing.T) {
+	if got, want := utf8Default, Encoding(0); got != want {
+		t.Fatalf("got encoding %d want %d", got, want)
+	}
+	if got, want := UTF8, Encoding(1); got != want {
+		t.Fatalf("got encoding %d want %d", got, want)
+	}
+	if got, want := ISO_8859_1, Encoding(2); got != want {
+		t.Fatalf("got encoding %d want %d", got, want)
+	}
+}
+
 func TestLoadFailsWithNotExistingFile(t *testing.T) {
 	_, err := LoadFile("doesnotexist.properties", ISO_8859_1)
 	assert.Equal(t, err != nil, true, "")

--- a/properties.go
+++ b/properties.go
@@ -85,7 +85,8 @@ func NewProperties() *Properties {
 
 // Load reads a buffer into the given Properties struct.
 func (p *Properties) Load(buf []byte, enc Encoding) error {
-	newProperties, err := loadBuf(buf, enc, p.DisableExpansion)
+	l := &Loader{Encoding: enc, DisableExpansion: p.DisableExpansion}
+	newProperties, err := l.LoadBytes(buf)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This patch refactors the loading functions and moves them into a general Loader object. 

It also ensures that the `DisableExpansion` flag from #26 is propagated to the Properties object. 