### PR TITLE
leaveing the backslash character

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -321,6 +321,7 @@ func (l *lexer) scanEscapeSequence() error {
 
 	// silently drop the escape character and append the rune as is
 	default:
+		l.appendRune('\\') // Assumes the escape character is put on purpose
 		l.appendRune(r)
 		return nil
 	}

--- a/properties_test.go
+++ b/properties_test.go
@@ -65,9 +65,10 @@ var complexTests = [][]string{
 	{"key = v\\ralue", "key", "v\ralue"},
 	{"key = v\\talue", "key", "v\talue"},
 
-	// silently dropped escape character
-	{"k\\zey = value", "kzey", "value"},
-	{"key = v\\zalue", "key", "vzalue"},
+	// doesn't drop escape character
+	{"k\\zey = value", "k\\zey", "value"},
+	{"key = v\\zalue", "key", "v\\zalue"},
+	{"key1 = \\{name\\} \\\\{value}", "key1", "\\{name\\} \\\\{value}"},
 
 	// unicode literals
 	{"key\\u2318 = value", "key⌘", "value"},


### PR DESCRIPTION
This change leaves the escape character backslash '\' when the backslash isn't precede one of " :=fnrt" that need escaping. Currently, any backslash that isn't precede one of the escaped characters is simply dropped.
We don't know how each property value will be processed by the callers. 
So, it would be better that the package 'properties' doesn't make modifications as possible because the backslash may be put on purpose.