### PR TITLE
Add preserveFormatting option for comments/whitespace 

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -278,7 +278,7 @@ func TestDecodeMap(t *testing.T) {
 }
 
 func testDecode(t *testing.T, in string, v, out interface{}) {
-	p, err := parse(in)
+	p, err := parse(in, false)
 	if err != nil {
 		t.Fatalf("got %v want nil", err)
 	}

--- a/lex.go
+++ b/lex.go
@@ -198,20 +198,15 @@ func lexBeforeKey(l *lexer) stateFn {
 		l.ignore()
 		return lexBeforeKey
 
-	case isComment(r) && l.keepWS:
+	case isComment(r):
 		// treat as part of the next key's comments block
 		// use existing prefix r as the comment's prefix
 		l.appendRune(r)
 		return lexComment
 
-	case isComment(r):
-		// use "#" as the comment's prefix
-		l.appendRune('#')
-		return lexComment
-
 	case isWhitespace(r) && l.keepWS:
 		// treat as part of the next key's comments block
-		// add the whitespace rune r as the comment's prefix
+		// add the whitespace rune r as part of the comment's prefix
 		l.appendRune(r)
 		return lexBeforeKey
 
@@ -232,7 +227,6 @@ func lexComment(l *lexer) stateFn {
 		l.ignore()
 	}
 	for {
-
 		switch r := l.next(); {
 		case isEOF(r):
 			if ! l.keepWS {

--- a/load.go
+++ b/load.go
@@ -45,11 +45,16 @@ type Loader struct {
 	// 404 are reported as errors. When set to true, missing files and 404
 	// status codes are not reported as errors.
 	IgnoreMissing bool
+
+	// PreserveFormatting causes the loader to scan whitespace as part of the
+	// comments for the next key. These can then be written out by passing
+	// a similar preserveFormatting argument to WriteCommentWithFormatting.
+	PreserveFormatting bool
 }
 
 // Load reads a buffer into a Properties struct.
 func (l *Loader) LoadBytes(buf []byte) (*Properties, error) {
-	return l.loadBytes(buf, l.Encoding)
+	return l.loadBytes(buf, l.Encoding, l.PreserveFormatting)
 }
 
 // LoadAll reads the content of multiple URLs or files in the given order into
@@ -99,7 +104,7 @@ func (l *Loader) LoadFile(filename string) (*Properties, error) {
 		}
 		return nil, err
 	}
-	return l.loadBytes(data, l.Encoding)
+	return l.loadBytes(data, l.Encoding, l.PreserveFormatting)
 }
 
 // LoadURL reads the content of the URL into a Properties struct.
@@ -142,11 +147,11 @@ func (l *Loader) LoadURL(url string) (*Properties, error) {
 		return nil, fmt.Errorf("properties: invalid content type %s", ct)
 	}
 
-	return l.loadBytes(body, enc)
+	return l.loadBytes(body, enc, l.PreserveFormatting)
 }
 
-func (l *Loader) loadBytes(buf []byte, enc Encoding) (*Properties, error) {
-	p, err := parse(convert(buf, enc))
+func (l *Loader) loadBytes(buf []byte, enc Encoding, preserveFormatting bool) (*Properties, error) {
+	p, err := parse(convert(buf, enc), preserveFormatting)
 	if err != nil {
 		return nil, err
 	}
@@ -176,6 +181,10 @@ func LoadMap(m map[string]string) *Properties {
 		p.Set(k, v)
 	}
 	return p
+}
+
+func GetLoader() (*Loader, error) {
+	return &Loader{}, nil
 }
 
 // LoadFile reads a file into a Properties struct.

--- a/load.go
+++ b/load.go
@@ -54,7 +54,7 @@ type Loader struct {
 
 // Load reads a buffer into a Properties struct.
 func (l *Loader) LoadBytes(buf []byte) (*Properties, error) {
-	return l.loadBytes(buf, l.Encoding, l.PreserveFormatting)
+	return l.loadBytes(buf, l.Encoding)
 }
 
 // LoadAll reads the content of multiple URLs or files in the given order into
@@ -104,7 +104,7 @@ func (l *Loader) LoadFile(filename string) (*Properties, error) {
 		}
 		return nil, err
 	}
-	return l.loadBytes(data, l.Encoding, l.PreserveFormatting)
+	return l.loadBytes(data, l.Encoding)
 }
 
 // LoadURL reads the content of the URL into a Properties struct.
@@ -147,11 +147,11 @@ func (l *Loader) LoadURL(url string) (*Properties, error) {
 		return nil, fmt.Errorf("properties: invalid content type %s", ct)
 	}
 
-	return l.loadBytes(body, enc, l.PreserveFormatting)
+	return l.loadBytes(body, enc)
 }
 
-func (l *Loader) loadBytes(buf []byte, enc Encoding, preserveFormatting bool) (*Properties, error) {
-	p, err := parse(convert(buf, enc), preserveFormatting)
+func (l *Loader) loadBytes(buf []byte, enc Encoding) (*Properties, error) {
+	p, err := parse(convert(buf, enc), l.PreserveFormatting)
 	if err != nil {
 		return nil, err
 	}
@@ -181,10 +181,6 @@ func LoadMap(m map[string]string) *Properties {
 		p.Set(k, v)
 	}
 	return p
-}
-
-func GetLoader() (*Loader, error) {
-	return &Loader{}, nil
 }
 
 // LoadFile reads a file into a Properties struct.

--- a/parser.go
+++ b/parser.go
@@ -7,30 +7,53 @@ package properties
 import (
 	"fmt"
 	"runtime"
+	"strings"
 )
 
 type parser struct {
 	lex *lexer
 }
 
-func parse(input string) (properties *Properties, err error) {
-	p := &parser{lex: lex(input)}
+func parse(input string, preserveFormatting bool) (properties *Properties, err error) {
+	p := &parser{lex: lex(input, preserveFormatting)}
 	defer p.recover(&err)
 
 	properties = NewProperties()
+	properties.PreserveFormatting = preserveFormatting
 	key := ""
-	comments := []string{}
+	comments := []Comment{}
 
 	for {
 		token := p.expectOneOf(itemComment, itemKey, itemEOF)
 		switch token.typ {
 		case itemEOF:
+			if preserveFormatting && (len(comments) > 0 || token.val != "") {
+				// There are comments at the end of the input that are not tied to a particular key
+				// Save these off against a special empty key when preserving formatting
+				if token.val != "" {
+					prefixIndex := 0
+					// Include leading whitespace into the prefix
+					prefixIndex = strings.Index(token.val, strings.TrimSpace(token.val))
+					prefix := token.val[0 : prefixIndex+1]
+					comment := Comment{prefix, token.val[prefixIndex+1 : len(token.val)]}
+					comments = append(comments, comment)
+				}
+				properties.c[""] = comments
+			}
 			goto done
 		case itemComment:
-			comments = append(comments, token.val)
+			prefix := "#"
+			prefixIndex := 0
+			if preserveFormatting {
+				// Include leading whitespace into the prefix
+				prefixIndex = strings.Index(token.val, strings.TrimSpace(token.val))
+				prefix = token.val[0:prefixIndex+1]
+			}
+			comment := Comment{prefix, token.val[prefixIndex+1:len(token.val)]}
+			comments = append(comments, comment)
 			continue
 		case itemKey:
-			key = token.val
+			key = strings.TrimSpace(token.val)
 			if _, ok := properties.m[key]; !ok {
 				properties.k = append(properties.k, key)
 			}
@@ -39,7 +62,7 @@ func parse(input string) (properties *Properties, err error) {
 		token = p.expectOneOf(itemValue, itemEOF)
 		if len(comments) > 0 {
 			properties.c[key] = comments
-			comments = []string{}
+			comments = []Comment{}
 		}
 		switch token.typ {
 		case itemEOF:

--- a/properties_test.go
+++ b/properties_test.go
@@ -787,7 +787,7 @@ func TestMustSet(t *testing.T) {
 
 func TestWrite(t *testing.T) {
 	for _, test := range writeTests {
-		p, err := parse(test.input)
+		p, err := parse(test.input, false)
 
 		buf := new(bytes.Buffer)
 		var n int
@@ -806,7 +806,7 @@ func TestWrite(t *testing.T) {
 
 func TestWriteComment(t *testing.T) {
 	for _, test := range writeCommentTests {
-		p, err := parse(test.input)
+		p, err := parse(test.input, false)
 
 		buf := new(bytes.Buffer)
 		var n int
@@ -970,7 +970,7 @@ func assertKeyValues(t *testing.T, input string, p *Properties, keyvalues ...str
 }
 
 func mustParse(t *testing.T, s string) *Properties {
-	p, err := parse(s)
+	p, err := parse(s, false)
 	if err != nil {
 		t.Fatalf("parse failed with %s", err)
 	}

--- a/properties_test.go
+++ b/properties_test.go
@@ -884,6 +884,7 @@ func TestMustSet(t *testing.T) {
 func TestWrite(t *testing.T) {
 	for _, test := range writeTests {
 		p, err := parse(test.input, false)
+		assert.Equal(t, err, nil)
 
 		buf := new(bytes.Buffer)
 		var n int
@@ -903,6 +904,7 @@ func TestWrite(t *testing.T) {
 func TestWriteComment(t *testing.T) {
 	for _, test := range writeCommentTests {
 		p, err := parse(test.input, false)
+		assert.Equal(t, err, nil)
 
 		buf := new(bytes.Buffer)
 		var n int
@@ -922,14 +924,15 @@ func TestWriteComment(t *testing.T) {
 func TestWriteCommentWithFormatting(t *testing.T) {
 	for _, test := range writeCommentWithFormattingTests {
 		p, err := parse(test.input, true)
+		assert.Equal(t, err, nil)
 
 		buf := new(bytes.Buffer)
 		var n int
 		switch test.encoding {
 		case "UTF-8":
-			n, err = p.WriteCommentWithFormatting(buf, "", UTF8, true)
+			n, err = p.WriteFormattedComment(buf, UTF8)
 		case "ISO-8859-1":
-			n, err = p.WriteCommentWithFormatting(buf, "", ISO_8859_1, true)
+			n, err = p.WriteFormattedComment(buf, ISO_8859_1)
 		}
 		assert.Equal(t, err, nil)
 		s := string(buf.Bytes())
@@ -942,6 +945,7 @@ func TestWriteCommentWithFormatting(t *testing.T) {
 func TestWriteFormattedCommentWithoutFormatting(t *testing.T) {
 	for _, test := range writeFormattedCommentWithoutFormattingTests {
 		p, err := parse(test.input, true)
+		assert.Equal(t, err, nil)
 
 		buf := new(bytes.Buffer)
 		var n int


### PR DESCRIPTION
This pull request addresses a use case for reading and updating properties files that have:
* commented out sample values for key/value entries that need to be preserved. eg:
```
# Uncomment the following to override the default value
# serverHostname = host.com
```
* sectional comments with whitespace formatting. eg:
```
# 
# Section 1 
#

# comment1
key = value
```

Changes:
* Add a preserveFormatting bool option to the loader to allow scanning and retaining whitespace as part of comments.
* Add a preserveFormatting bool option when writing comments to pass through the whitespace formatting to the output.
* Add a virtual key/value for the end of the input to allow trailing comments to be retained and emitted.
* Update lexer to not discard whitespace if preserveFormatting is set.
* Comments are now structs containing 2 elements: the original prefixes from the input, and the comment value itself.

Notes:
* I chose not to add a preserveFormatting option to each of the Load* methods. I felt doing this would explode the number of combinations of potential parameters.
  * Instead, the preserveFormatting option for loading is only available through the GetLoader method followed by explicitly setting the loader options before invoking the underlying Load methods.