### PR TITLE
Sorting property keys

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -584,6 +585,12 @@ func (p *Properties) String() string {
 		s = fmt.Sprintf("%s%s = %s\n", s, key, value)
 	}
 	return s
+}
+
+// Sort sorts the properties keys in alphabetical order.
+// This is helpfully before writing the properties.
+func (p *Properties) Sort() {
+	sort.Strings(p.k)
 }
 
 // Write writes all unexpanded 'key = value' pairs to the given writer.


### PR DESCRIPTION
We're processing a lot of property files in Git repositories. To see easily differences of property changes (and not structure or order changes) the property files are sorted by their key.
With this pull request this great properties module will be able to sort the property keys in alphabetical order. There are no changes of the current functionality.