### PR TITLE
Specification of key and value separator added

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -69,6 +69,9 @@ type Properties struct {
 
 	// Stores the keys in order of appearance.
 	k []string
+
+	// WriteSeparator specifies the separator of key and value while writing the properties.
+	WriteSeparator string
 }
 
 // NewProperties creates a new Properties struct with the default
@@ -635,8 +638,10 @@ func (p *Properties) WriteComment(w io.Writer, prefix string, enc Encoding) (n i
 				}
 			}
 		}
-
-		x, err = fmt.Fprintf(w, "%s = %s\n", encode(key, " :", enc), encode(value, "", enc))
+        if p.WriteSeparator == "" {
+			p.WriteSeparator = " = "
+		}
+		x, err = fmt.Fprintf(w, "%s%s%s\n", encode(key, " :", enc), p.WriteSeparator, encode(value, "", enc))
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
We're processing a lot of property files in Git repositories. There are now Go an Java tools working on them. To see easily differences of property changes (and not structure or order changes) the written property files should not differ depending the tool technology.
With this pull request this great properties module will provide the ability to set the separator string between key and value while writing. There are no changes of the current functionality.