### PR TITLE
Made Content-Type check whitespace agnostic in LoadURL()

### DIFF
--- a/load.go
+++ b/load.go
@@ -132,11 +132,12 @@ func (l *Loader) LoadURL(url string) (*Properties, error) {
 	}
 
 	ct := resp.Header.Get("Content-Type")
+	ct = strings.Join(strings.Fields(ct), "")
 	var enc Encoding
 	switch strings.ToLower(ct) {
-	case "text/plain", "text/plain; charset=iso-8859-1", "text/plain; charset=latin1":
+	case "text/plain", "text/plain;charset=iso-8859-1", "text/plain;charset=latin1":
 		enc = ISO_8859_1
-	case "", "text/plain; charset=utf-8":
+	case "", "text/plain;charset=utf-8":
 		enc = UTF8
 	default:
 		return nil, fmt.Errorf("properties: invalid content type %s", ct)


### PR DESCRIPTION
When loading properties from URLs, if a web server defined its Content-Type without any whitespaces between the text type and charset, the load fails with an invalid content type error. E.g.
```text/plain;charset=utf-8``` instead of
```text/plain; charset=utf-8```.

This PR makes the Content-Type check whitespace agnostic by removing all whitespace characters from the header field and comparing it to the appropriate strings.