### PR TITLE
Include the key in error message causing the circular reference

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -115,7 +115,7 @@ func (p *Properties) Get(key string) (value string, ok bool) {
 	// circular references and malformed expressions
 	// so we panic if we still get an error here.
 	if err != nil {
-		ErrorHandler(fmt.Errorf("%s in %q", err, key+" = "+v))
+		ErrorHandler(err)
 	}
 
 	return expanded, true
@@ -766,7 +766,7 @@ func expand(s string, keys []string, prefix, postfix string, values map[string]s
 
 		for _, k := range keys {
 			if key == k {
-				return "", fmt.Errorf("circular reference")
+				return "", fmt.Errorf("circular reference in %q", key + " = " + prefix + k + postfix)
 			}
 		}
 

--- a/properties_test.go
+++ b/properties_test.go
@@ -796,7 +796,7 @@ func TestSetValue(t *testing.T) {
 func TestMustSet(t *testing.T) {
 	input := "key=${key}"
 	p := mustParse(t, input)
-	assert.Panic(t, func() { p.MustSet("key", "${key}") }, "circular reference .*")
+	assert.Panic(t, func() { p.MustSet("key", "${key}") }, `circular reference in "key = \$\{key\}"`)
 }
 
 func TestWrite(t *testing.T) {


### PR DESCRIPTION
The change is include the key in the error message which is causing the circular reference when parsing/loading the properties files.

We're using this library as part of the getgauge/gauge project and it lets you set properties in files and env variables. This is to aid in debugging for users when there's an actual circular reference.
