### PR TITLE
enhance error message for circular references

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -766,7 +766,12 @@ func expand(s string, keys []string, prefix, postfix string, values map[string]s
 
 		for _, k := range keys {
 			if key == k {
-				return "", fmt.Errorf("circular reference in %q", key + " = " + prefix + k + postfix)
+				var b strings.Builder
+				b.WriteString("circular reference in:\n")
+				for _, k1 := range keys {
+					fmt.Fprintf(&b, "%s=%s\n", k1, values[k1])
+				}
+				return "", fmt.Errorf(b.String())
 			}
 		}
 

--- a/properties.go
+++ b/properties.go
@@ -8,6 +8,7 @@ package properties
 // BUG(frank): Write() does not allow to configure the newline character. Therefore, on Windows LF is used.
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -766,7 +767,7 @@ func expand(s string, keys []string, prefix, postfix string, values map[string]s
 
 		for _, k := range keys {
 			if key == k {
-				var b strings.Builder
+				var b bytes.Buffer
 				b.WriteString("circular reference in:\n")
 				for _, k1 := range keys {
 					fmt.Fprintf(&b, "%s=%s\n", k1, values[k1])

--- a/properties_test.go
+++ b/properties_test.go
@@ -134,8 +134,8 @@ var errorTests = []struct {
 	{"key\\u123", "invalid unicode literal"},
 
 	// circular references
-	{"key=${key}", "circular reference"},
-	{"key1=${key2}\nkey2=${key1}", "circular reference"},
+	{"key=${key}", "circular reference in:\nkey=${key}"},
+	{"key1=${key2}\nkey2=${key1}", "circular reference in:\nkey1=${key2}\nkey2=${key1}"},
 
 	// malformed expressions
 	{"key=${ke", "malformed expression"},
@@ -450,8 +450,8 @@ func TestComplex(t *testing.T) {
 func TestErrors(t *testing.T) {
 	for _, test := range errorTests {
 		_, err := Load([]byte(test.input), ISO_8859_1)
-		assert.Equal(t, err != nil, true, "want error")
-		assert.Equal(t, strings.Contains(err.Error(), test.msg), true)
+		assert.Equal(t, err != nil, true, fmt.Sprintf("want error: %s", test.input))
+		assert.Equal(t, strings.Contains(err.Error(), test.msg), true, fmt.Sprintf("expected %s, got %s", test.msg, err.Error()))
 	}
 }
 
@@ -796,7 +796,8 @@ func TestSetValue(t *testing.T) {
 func TestMustSet(t *testing.T) {
 	input := "key=${key}"
 	p := mustParse(t, input)
-	assert.Panic(t, func() { p.MustSet("key", "${key}") }, `circular reference in "key = \$\{key\}"`)
+	e := `circular reference in:\nkey=\$\{key\}`
+	assert.Panic(t, func() { p.MustSet("key", "${key}") }, e)
 }
 
 func TestWrite(t *testing.T) {


### PR DESCRIPTION
> Note: This is an improvement over #49 for circular reference error message.


## Context

When there are properties with circular references, the error message thrown contains one of the key in the cycle. This can be a bit annoying to fix, since it does not give a trace. Given this library supports loading properties from multiple sources, `grep` etc can fail.

## Input:

```properties
foo = depends on ${bar}

bar = which depends on ${baz}

baz = ${foo} completes a cyclic reference

```

The error message thrown when `properties.MustLoadFile` is called with the above file:

```
circular reference in "foo = ${foo}"
```

This pull request is an attempt to make it look better, my take:

```
circular reference in:
foo=depends on ${bar}
bar=which depends on ${baz}
baz=${foo} completes a cyclic reference
```

This is not perfect, it still does not highlight the exact source of these properties, but I felt that the overhead of carrying that context to [`properties.expand`](https://github.com/magiconair/properties/blob/632ce30ece2b5b1c37d503225747f0284797b9e9/properties.go#L745) may be a bit too much, since the method is currently stateless.

Thanks for the library!