### PR TITLE
Properly compare versions equal or over to 1.15 in TestMustGetParsedD…

### DIFF
--- a/properties_test.go
+++ b/properties_test.go
@@ -560,12 +560,17 @@ func TestMustGetParsedDuration(t *testing.T) {
 	assert.Equal(t, p.MustGetParsedDuration("key"), 123*time.Millisecond)
 
 	ver := runtime.Version()
-	switch {
-	// gotip and go1.15 will return `time: invalid duration "ghi"`
-	case !strings.HasPrefix(ver, "go") || strings.HasPrefix(ver, "go1.15"):
-		assert.Panic(t, func() { p.MustGetParsedDuration("key2") }, `time: invalid duration "ghi"`)
-	default:
-		assert.Panic(t, func() { p.MustGetParsedDuration("key2") }, `time: invalid duration ghi`)
+	if strings.HasPrefix(ver, "go") {
+		ver_minor := ver[4:6]
+		switch {
+		// gotip and go1.15 will return `time: invalid duration "ghi"`
+		case ver_minor >= "15":
+			assert.Panic(t, func() { p.MustGetParsedDuration("key2") }, `time: invalid duration "ghi"`)
+		default:
+			assert.Panic(t, func() { p.MustGetParsedDuration("key2") }, `time: invalid duration ghi`)
+		}
+	} else {
+			assert.Panic(t, func() { p.MustGetParsedDuration("key2") }, `time: invalid duration "ghi"`)
 	}
 
 	assert.Panic(t, func() { p.MustGetParsedDuration("invalid") }, "unknown property: invalid")


### PR DESCRIPTION
…uration

Fix #52

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>

I have tested this with Go 1.14 and Go 1.16. It won't work over Go 1.99 and Go 2.x, and not below 1.10, but since the minimun required version is go 1.13, I don't think this is an issue.