### PR TITLE
Skip ignored private fields

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -189,11 +189,11 @@ func dec(p *Properties, key string, def *string, opts map[string]string, v refle
 		for i := 0; i < v.NumField(); i++ {
 			fv := v.Field(i)
 			fk, def, opts := keydef(t.Field(i))
-			if !fv.CanSet() {
-				return fmt.Errorf("cannot set %s", t.Field(i).Name)
-			}
 			if fk == "-" {
 				continue
+			}
+			if !fv.CanSet() {
+				return fmt.Errorf("cannot set %s", t.Field(i).Name)
 			}
 			if key != "" {
 				fk = key + "." + fk

--- a/decode_test.go
+++ b/decode_test.go
@@ -213,11 +213,12 @@ func TestDecodeArrayDefaults(t *testing.T) {
 
 func TestDecodeSkipUndef(t *testing.T) {
 	type S struct {
+		p     string `properties:"-"`
 		X     string `properties:"-"`
 		Undef string `properties:",default=some value"`
 	}
 	in := `X=ignore`
-	out := &S{"", "some value"}
+	out := &S{"", "", "some value"}
 	testDecode(t, in, &S{}, out)
 }
 


### PR DESCRIPTION
This pull request allows adding some private fields on properties structs without having problems, only marking this field as skipped with a specific tag as the test example below.:

```go
	type S struct {
		p     string `properties:"-"`
		X     string `properties:"-"`
		Undef string `properties:",default=some value"`
	}
```

This change will avoid an error `cannot set p` using the struct above.