### PR TITLE
TestMustGetParsedDuration: drop version tests

### DIFF
--- a/properties_go1.15_test.go
+++ b/properties_go1.15_test.go
@@ -1,0 +1,25 @@
+//go:build go1.15
+// +build go1.15
+
+package properties
+
+import (
+	"testing"
+	"time"
+
+	"github.com/magiconair/properties/assert"
+)
+
+// TestMustGetParsedDuration works with go1.15 and beyond where the panic
+// message was changed slightly. We keep this test (!) here to demonstrate the
+// backwards compatibility and to keep the author happy as long as it does not
+// affect any real users. Thank you! Frank :)
+//
+// See https://github.com/magiconair/properties/pull/63
+func TestMustGetParsedDuration(t *testing.T) {
+	input := "key = 123ms\nkey2 = ghi"
+	p := mustParse(t, input)
+	assert.Equal(t, p.MustGetParsedDuration("key"), 123*time.Millisecond)
+	assert.Panic(t, func() { p.MustGetParsedDuration("key2") }, `time: invalid duration "ghi"`)
+	assert.Panic(t, func() { p.MustGetParsedDuration("invalid") }, "unknown property: invalid")
+}

--- a/properties_pre_go1.15_test.go
+++ b/properties_pre_go1.15_test.go
@@ -1,0 +1,25 @@
+//go:build !go1.15
+// +build !go1.15
+
+package properties
+
+import (
+	"testing"
+	"time"
+
+	"github.com/magiconair/properties/assert"
+)
+
+// TestMustGetParsedDuration works with go before go1.15 where the panic
+// message was changed slightly. We keep this test (!) here to demonstrate the
+// backwards compatibility and to keep the author happy as long as it does not
+// affect any real users. Thank you! Frank :)
+//
+// See https://github.com/magiconair/properties/pull/63
+func TestMustGetParsedDuration(t *testing.T) {
+	input := "key = 123ms\nkey2 = ghi"
+	p := mustParse(t, input)
+	assert.Equal(t, p.MustGetParsedDuration("key"), 123*time.Millisecond)
+	assert.Panic(t, func() { p.MustGetParsedDuration("key2") }, `time: invalid duration ghi`)
+	assert.Panic(t, func() { p.MustGetParsedDuration("invalid") }, "unknown property: invalid")
+}

--- a/properties_test.go
+++ b/properties_test.go
@@ -554,14 +554,6 @@ func TestGetParsedDuration(t *testing.T) {
 	}
 }
 
-func TestMustGetParsedDuration(t *testing.T) {
-	input := "key = 123ms\nkey2 = ghi"
-	p := mustParse(t, input)
-	assert.Equal(t, p.MustGetParsedDuration("key"), 123*time.Millisecond)
-	assert.Panic(t, func() { p.MustGetParsedDuration("key2") }, `time: invalid duration "ghi"`)
-	assert.Panic(t, func() { p.MustGetParsedDuration("invalid") }, "unknown property: invalid")
-}
-
 func TestGetFloat64(t *testing.T) {
 	for _, test := range floatTests {
 		p := mustParse(t, test.input)

--- a/properties_test.go
+++ b/properties_test.go
@@ -11,8 +11,6 @@ import (
 	"os"
 	"reflect"
 	"regexp"
-	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -560,24 +558,7 @@ func TestMustGetParsedDuration(t *testing.T) {
 	input := "key = 123ms\nkey2 = ghi"
 	p := mustParse(t, input)
 	assert.Equal(t, p.MustGetParsedDuration("key"), 123*time.Millisecond)
-
-	// parse runtime.Version into major and minor version
-	var major, minor int
-	ver := strings.Split(runtime.Version(), ".")
-	devel := !strings.HasPrefix(ver[0], "go")
-	major, _ = strconv.Atoi(strings.TrimPrefix(ver[0], "go"))
-	if len(ver) > 1 {
-		minor, _ = strconv.Atoi(ver[1])
-	}
-
-	switch {
-	case devel || major == 1 && minor >= 15:
-		// go1.15 ... gotip
-		assert.Panic(t, func() { p.MustGetParsedDuration("key2") }, `time: invalid duration "ghi"`)
-	default:
-		// go1.x..go1.14
-		assert.Panic(t, func() { p.MustGetParsedDuration("key2") }, `time: invalid duration ghi`)
-	}
+	assert.Panic(t, func() { p.MustGetParsedDuration("key2") }, `time: invalid duration "ghi"`)
 	assert.Panic(t, func() { p.MustGetParsedDuration("invalid") }, "unknown property: invalid")
 }
 


### PR DESCRIPTION
Fails:

% go version
go version go1.18beta2 linux/amd64

As per:

	https://go.dev/doc/devel/release#policy

Supported versions are today 1.16 and 1.17, so we can drop this brittle check.