### PR TITLE
⚡ Speedup merge

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -700,21 +700,16 @@ func (p *Properties) Delete(key string) {
 
 // Merge merges properties, comments and keys from other *Properties into p
 func (p *Properties) Merge(other *Properties) {
+	for _, k := range other.k {
+		if _, ok := p.m[k]; !ok {
+			p.k = append(p.k, k)
+		}
+	}
 	for k, v := range other.m {
 		p.m[k] = v
 	}
 	for k, v := range other.c {
 		p.c[k] = v
-	}
-
-outer:
-	for _, otherKey := range other.k {
-		for _, key := range p.k {
-			if otherKey == key {
-				continue outer
-			}
-		}
-		p.k = append(p.k, otherKey)
 	}
 }
 

--- a/properties_test.go
+++ b/properties_test.go
@@ -913,6 +913,37 @@ func TestLoad(t *testing.T) {
 
 // ----------------------------------------------------------------------------
 
+var inputs = []struct {
+	input int
+}{
+	{input: 1e2},
+	{input: 1e3},
+	{input: 1e4},
+	{input: 1e5},
+}
+
+func BenchmarkMerge(b *testing.B) {
+	for _, v := range inputs {
+		p := generateProperties(v.input)
+		b.Run(fmt.Sprintf("num_properties_%d", v.input), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				p.Merge(p)
+			}
+		})
+	}
+}
+
+func generateProperties(n int) *Properties {
+	p := NewProperties()
+	for i := 0; i < n; i++ {
+		s := fmt.Sprintf("%v", i)
+		p.Set(s, s)
+	}
+	return p
+}
+
+// ----------------------------------------------------------------------------
+
 // tests all combinations of delimiters, leading and/or trailing whitespace and newlines.
 func testWhitespaceAndDelimiterCombinations(t *testing.T, key, value string) {
 	whitespace := []string{"", " ", "\f", "\t"}


### PR DESCRIPTION
The `Merge` function currently checks if a key in `other` exists in `p` by iterating over all keys in `p` which is redundant as we already have a faster way to look that up in `p.m`.

This reduces the asymptotic complexity of `Merge` from quadratic **O(N<sup>2</sup>)** down to linear **O(N)** where `N` is the number of properties.

Also wrote a benchmark to measure the exact speedup and here are the results:

Merging hundred properties             **- 6x faster**
Merging thousand properties           **- 37x faster**
Merging 10K properties.   **- 300x faster**
Merging 100K properties                **- 2600x faster**

**Before**
```
$ GOMAXPROCS=1 go test -run=^$ -bench ^BenchmarkMerge$ github.com/magiconair/properties
goos: linux
goarch: amd64
pkg: github.com/magiconair/properties
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkMerge/num_properties_100                  58174             19691 ns/op
BenchmarkMerge/num_properties_1000                   687           1637600 ns/op
BenchmarkMerge/num_properties_10000                    7         156907466 ns/op
BenchmarkMerge/num_properties_100000                   1        16630149940 ns/op
PASS
```

**After**
```
$ GOMAXPROCS=1 go test -run=^$ -bench ^BenchmarkMerge$ github.com/magiconair/properties
goos: linux
goarch: amd64
pkg: github.com/magiconair/properties
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkMerge/num_properties_100                 342036              3254 ns/op
BenchmarkMerge/num_properties_1000                 27264             44239 ns/op
BenchmarkMerge/num_properties_10000                 2245            523613 ns/op
BenchmarkMerge/num_properties_100000                 190           6237122 ns/op
PASS
```
