### PR TITLE
Add 32bit numeric getters which do not panic

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -306,6 +306,40 @@ func (p *Properties) getFloat64(key string) (value float64, err error) {
 
 // ----------------------------------------------------------------------------
 
+// GetFloat32 parses the expanded value as a float32 if the key exists.
+// If key does not exist or the value cannot be parsed the default
+// value is returned.
+func (p *Properties) GetFloat32(key string, def float32) float32 {
+	v, err := p.getFloat32(key)
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+// MustGetFloat32 parses the expanded value as a float32 if the key exists.
+// If key does not exist or the value cannot be parsed the function panics.
+func (p *Properties) MustGetFloat32(key string) float32 {
+	v, err := p.getFloat32(key)
+	if err != nil {
+		ErrorHandler(err)
+	}
+	return v
+}
+
+func (p *Properties) getFloat32(key string) (value float32, err error) {
+	if v, ok := p.Get(key); ok {
+		n, err := strconv.ParseFloat(v, 32)
+		if err != nil {
+			return 0, err
+		}
+		return float32(n), nil
+	}
+	return 0, invalidKeyError(key)
+}
+
+// ----------------------------------------------------------------------------
+
 // GetInt parses the expanded value as an int if the key exists.
 // If key does not exist or the value cannot be parsed the default
 // value is returned. If the value does not fit into an int the
@@ -366,6 +400,40 @@ func (p *Properties) getInt64(key string) (value int64, err error) {
 
 // ----------------------------------------------------------------------------
 
+// GetInt32 parses the expanded value as an int32 if the key exists.
+// If key does not exist or the value cannot be parsed the default
+// value is returned.
+func (p *Properties) GetInt32(key string, def int32) int32 {
+	v, err := p.getInt32(key)
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+// MustGetInt32 parses the expanded value as an int if the key exists.
+// If key does not exist or the value cannot be parsed the function panics.
+func (p *Properties) MustGetInt32(key string) int32 {
+	v, err := p.getInt32(key)
+	if err != nil {
+		ErrorHandler(err)
+	}
+	return v
+}
+
+func (p *Properties) getInt32(key string) (value int32, err error) {
+	if v, ok := p.Get(key); ok {
+		n, err := strconv.ParseInt(v, 10, 32)
+		if err != nil {
+			return 0, err
+		}
+		return int32(n), nil
+	}
+	return 0, invalidKeyError(key)
+}
+
+// ----------------------------------------------------------------------------
+
 // GetUint parses the expanded value as an uint if the key exists.
 // If key does not exist or the value cannot be parsed the default
 // value is returned. If the value does not fit into an int the
@@ -420,6 +488,40 @@ func (p *Properties) getUint64(key string) (value uint64, err error) {
 			return 0, err
 		}
 		return value, nil
+	}
+	return 0, invalidKeyError(key)
+}
+
+// ----------------------------------------------------------------------------
+
+// GetUint32 parses the expanded value as an uint32 if the key exists.
+// If key does not exist or the value cannot be parsed the default
+// value is returned.
+func (p *Properties) GetUint32(key string, def uint32) uint32 {
+	v, err := p.getUint32(key)
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+// MustGetUint32 parses the expanded value as an int if the key exists.
+// If key does not exist or the value cannot be parsed the function panics.
+func (p *Properties) MustGetUint32(key string) uint32 {
+	v, err := p.getUint32(key)
+	if err != nil {
+		ErrorHandler(err)
+	}
+	return v
+}
+
+func (p *Properties) getUint32(key string) (value uint32, err error) {
+	if v, ok := p.Get(key); ok {
+		n, err := strconv.ParseUint(v, 10, 32)
+		if err != nil {
+			return 0, err
+		}
+		return uint32(n), nil
 	}
 	return 0, invalidKeyError(key)
 }

--- a/properties_test.go
+++ b/properties_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -262,7 +263,7 @@ var parsedDurationTests = []struct {
 
 // ----------------------------------------------------------------------------
 
-var floatTests = []struct {
+var float64Tests = []struct {
 	input, key string
 	def, value float64
 }{
@@ -274,10 +275,38 @@ var floatTests = []struct {
 	{"key = 0", "key", 999, 0},
 	{"key = -1", "key", 999, -1},
 	{"key = 0123", "key", 999, 123},
+	{"key = " + strconv.FormatFloat(math.SmallestNonzeroFloat64, 'f', -1, 64), "key", 999, math.SmallestNonzeroFloat64},
+	{"key = " + strconv.FormatFloat(math.MaxFloat64, 'f', -1, 64), "key", 999, math.MaxFloat64},
 
 	// invalid values
 	{"key = 0xff", "key", 999, 999},
 	{"key = a", "key", 999, 999},
+
+	// non existent key
+	{"key = 1", "key2", 999, 999},
+}
+
+// ----------------------------------------------------------------------------
+
+var float32Tests = []struct {
+	input, key string
+	def, value float32
+}{
+	// valid values
+	{"key = 1.0", "key", 999, 1.0},
+	{"key = 0.0", "key", 999, 0.0},
+	{"key = -1.0", "key", 999, -1.0},
+	{"key = 1", "key", 999, 1},
+	{"key = 0", "key", 999, 0},
+	{"key = -1", "key", 999, -1},
+	{"key = 0123", "key", 999, 123},
+	{"key = " + strconv.FormatFloat(math.SmallestNonzeroFloat32, 'f', -1, 32), "key", 999, math.SmallestNonzeroFloat32},
+	{"key = " + strconv.FormatFloat(math.MaxFloat32, 'f', -1, 32), "key", 999, math.MaxFloat32},
+
+	// invalid values
+	{"key = 0xff", "key", 999, 999},
+	{"key = a", "key", 999, 999},
+	{"key = " + strconv.FormatFloat(math.MaxFloat32*10, 'f', -1, 64), "key", 999, 999},
 
 	// non existent key
 	{"key = 1", "key2", 999, 999},
@@ -294,11 +323,38 @@ var int64Tests = []struct {
 	{"key = 0", "key", 999, 0},
 	{"key = -1", "key", 999, -1},
 	{"key = 0123", "key", 999, 123},
+	{"key = " + strconv.FormatInt(math.MinInt64, 10), "key", 999, math.MinInt64},
+	{"key = " + strconv.FormatInt(math.MaxInt64, 10), "key", 999, math.MaxInt64},
 
 	// invalid values
 	{"key = 0xff", "key", 999, 999},
 	{"key = 1.0", "key", 999, 999},
 	{"key = a", "key", 999, 999},
+
+	// non existent key
+	{"key = 1", "key2", 999, 999},
+}
+
+// ----------------------------------------------------------------------------
+
+var int32Tests = []struct {
+	input, key string
+	def, value int32
+}{
+	// valid values
+	{"key = 1", "key", 999, 1},
+	{"key = 0", "key", 999, 0},
+	{"key = -1", "key", 999, -1},
+	{"key = 0123", "key", 999, 123},
+	{"key = " + strconv.FormatInt(math.MinInt32, 10), "key", 999, math.MinInt32},
+	{"key = " + strconv.FormatInt(math.MaxInt32, 10), "key", 999, math.MaxInt32},
+
+	// invalid values
+	{"key = 0xff", "key", 999, 999},
+	{"key = 1.0", "key", 999, 999},
+	{"key = a", "key", 999, 999},
+	{"key = " + strconv.FormatInt(math.MinInt32-1, 10), "key", 999, 999},
+	{"key = " + strconv.FormatInt(math.MaxInt32+1, 10), "key", 999, 999},
 
 	// non existent key
 	{"key = 1", "key2", 999, 999},
@@ -314,12 +370,36 @@ var uint64Tests = []struct {
 	{"key = 1", "key", 999, 1},
 	{"key = 0", "key", 999, 0},
 	{"key = 0123", "key", 999, 123},
+	{"key = " + strconv.FormatUint(math.MaxUint64, 10), "key", 999, math.MaxUint64},
 
 	// invalid values
 	{"key = -1", "key", 999, 999},
 	{"key = 0xff", "key", 999, 999},
 	{"key = 1.0", "key", 999, 999},
 	{"key = a", "key", 999, 999},
+
+	// non existent key
+	{"key = 1", "key2", 999, 999},
+}
+
+// ----------------------------------------------------------------------------
+
+var uint32Tests = []struct {
+	input, key string
+	def, value uint32
+}{
+	// valid values
+	{"key = 1", "key", 999, 1},
+	{"key = 0", "key", 999, 0},
+	{"key = 0123", "key", 999, 123},
+	{"key = " + strconv.FormatUint(math.MaxUint32, 10), "key", 999, math.MaxUint32},
+
+	// invalid values
+	{"key = -1", "key", 999, 999},
+	{"key = 0xff", "key", 999, 999},
+	{"key = 1.0", "key", 999, 999},
+	{"key = a", "key", 999, 999},
+	{"key = " + strconv.FormatUint(math.MaxUint32+1, 10), "key", 999, 999},
 
 	// non existent key
 	{"key = 1", "key2", 999, 999},
@@ -555,7 +635,7 @@ func TestGetParsedDuration(t *testing.T) {
 }
 
 func TestGetFloat64(t *testing.T) {
-	for _, test := range floatTests {
+	for _, test := range float64Tests {
 		p := mustParse(t, test.input)
 		assert.Equal(t, p.Len(), 1)
 		assert.Equal(t, p.GetFloat64(test.key, test.def), test.value)
@@ -568,6 +648,22 @@ func TestMustGetFloat64(t *testing.T) {
 	assert.Equal(t, p.MustGetFloat64("key"), float64(123))
 	assert.Panic(t, func() { p.MustGetFloat64("key2") }, "strconv.ParseFloat: parsing.*")
 	assert.Panic(t, func() { p.MustGetFloat64("invalid") }, "unknown property: invalid")
+}
+
+func TestGetFloat32(t *testing.T) {
+	for _, test := range float32Tests {
+		p := mustParse(t, test.input)
+		assert.Equal(t, p.Len(), 1)
+		assert.Equal(t, p.GetFloat32(test.key, test.def), test.value)
+	}
+}
+
+func TestMustGetFloat32(t *testing.T) {
+	input := "key = 123\nkey2 = ghi"
+	p := mustParse(t, input)
+	assert.Equal(t, p.MustGetFloat32("key"), float32(123))
+	assert.Panic(t, func() { p.MustGetFloat32("key2") }, "strconv.ParseFloat: parsing.*")
+	assert.Panic(t, func() { p.MustGetFloat32("invalid") }, "unknown property: invalid")
 }
 
 func TestGetInt(t *testing.T) {
@@ -602,6 +698,22 @@ func TestMustGetInt64(t *testing.T) {
 	assert.Panic(t, func() { p.MustGetInt64("invalid") }, "unknown property: invalid")
 }
 
+func TestGetInt32(t *testing.T) {
+	for _, test := range int32Tests {
+		p := mustParse(t, test.input)
+		assert.Equal(t, p.Len(), 1)
+		assert.Equal(t, p.GetInt32(test.key, test.def), test.value)
+	}
+}
+
+func TestMustGetInt32(t *testing.T) {
+	input := "key = 123\nkey2 = ghi"
+	p := mustParse(t, input)
+	assert.Equal(t, p.MustGetInt32("key"), int32(123))
+	assert.Panic(t, func() { p.MustGetInt32("key2") }, "strconv.ParseInt: parsing.*")
+	assert.Panic(t, func() { p.MustGetInt32("invalid") }, "unknown property: invalid")
+}
+
 func TestGetUint(t *testing.T) {
 	for _, test := range uint64Tests {
 		p := mustParse(t, test.input)
@@ -632,6 +744,22 @@ func TestMustGetUint64(t *testing.T) {
 	assert.Equal(t, p.MustGetUint64("key"), uint64(123))
 	assert.Panic(t, func() { p.MustGetUint64("key2") }, "strconv.ParseUint: parsing.*")
 	assert.Panic(t, func() { p.MustGetUint64("invalid") }, "unknown property: invalid")
+}
+
+func TestGetUint32(t *testing.T) {
+	for _, test := range uint32Tests {
+		p := mustParse(t, test.input)
+		assert.Equal(t, p.Len(), 1)
+		assert.Equal(t, p.GetUint32(test.key, test.def), test.value)
+	}
+}
+
+func TestMustGetUint32(t *testing.T) {
+	input := "key = 123\nkey2 = ghi"
+	p := mustParse(t, input)
+	assert.Equal(t, p.MustGetUint32("key"), uint32(123))
+	assert.Panic(t, func() { p.MustGetUint32("key2") }, "strconv.ParseUint: parsing.*")
+	assert.Panic(t, func() { p.MustGetUint32("invalid") }, "unknown property: invalid")
 }
 
 func TestGetString(t *testing.T) {


### PR DESCRIPTION
Add GetInt32, GetUint32 and GetFloat32 which return the default value when the key value is out of range just like their 64bit variants.

The generic GetInt, GetUint and GetFloat methods panic.

Closes #75