### PR TITLE
Fix getting default value for keys without values in decode

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -103,6 +103,9 @@ func (p *Properties) Load(buf []byte, enc Encoding) error {
 // Otherwise, ok is false.
 func (p *Properties) Get(key string) (value string, ok bool) {
 	v, ok := p.m[key]
+	if v == "" {
+		return "", false
+	}
 	if p.DisableExpansion {
 		return v, ok
 	}


### PR DESCRIPTION
Currently, when attempting to perform a Decode on a file that contains a key but no value, a crash occurs regardless of whether default values are present in the structure or not. This commit fixes the issue by using the default value if the value is missing in the properties file.