### PR TITLE
escape leading whitespace on value in Write()

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: ["1.23.x", "1.22.x", "1.21.x", "1.20.x", "1.19.x", "1.18.x"]
+        go: ["1.24.x", "1.23.x", "1.22.x", "1.21.x", "1.20.x", "1.19.x", "1.18.x"]
 
     steps:
       - name: Setup Go ${{ matrix.go }}

--- a/properties.go
+++ b/properties.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -901,8 +902,13 @@ func encodeUtf8(s string, special string) string {
 	v := ""
 	for pos := 0; pos < len(s); {
 		r, w := utf8.DecodeRuneInString(s[pos:])
+		switch {
+		case pos == 0 && unicode.IsSpace(r): // escape leading whitespace
+			v += escape(r, " ")
+		default:
+			v += escape(r, special) // escape special chars only
+		}
 		pos += w
-		v += escape(r, special)
 	}
 	return v
 }
@@ -913,6 +919,8 @@ func encodeIso(s string, special string) string {
 	var v string
 	for pos := 0; pos < len(s); {
 		switch r, w = utf8.DecodeRuneInString(s[pos:]); {
+		case pos == 0 && unicode.IsSpace(r): // escape leading whitespace
+			v += escape(r, " ")
 		case r < 1<<8: // single byte rune -> escape special chars only
 			v += escape(r, special)
 		case r < 1<<16: // two byte rune -> unicode literal

--- a/properties_test.go
+++ b/properties_test.go
@@ -147,6 +147,7 @@ var writeTests = []struct {
 }{
 	// ISO-8859-1 tests
 	{"key = value", "key = value\n", "ISO-8859-1"},
+	{"key = \\ value", "key = \\ value\n", "ISO-8859-1"},
 	{"key = value \\\n   continued", "key = value continued\n", "ISO-8859-1"},
 	{"key⌘ = value", "key\\u2318 = value\n", "ISO-8859-1"},
 	{"ke\\ \\:y = value", "ke\\ \\:y = value\n", "ISO-8859-1"},
@@ -154,6 +155,7 @@ var writeTests = []struct {
 
 	// UTF-8 tests
 	{"key = value", "key = value\n", "UTF-8"},
+	{"key = \\ value", "key = \\ value\n", "UTF-8"},
 	{"key = value \\\n   continued", "key = value continued\n", "UTF-8"},
 	{"key⌘ = value⌘", "key⌘ = value⌘\n", "UTF-8"},
 	{"ke\\ \\:y = value", "ke\\ \\:y = value\n", "UTF-8"},


### PR DESCRIPTION
This change escapes the leading whitespace of a value when writing the properties values via Write().

Fixes #80