### PR TITLE
fix: nil Properties.Get returns false

### DIFF
--- a/nil_get_test.go
+++ b/nil_get_test.go
@@ -1,0 +1,16 @@
+package properties
+
+import "testing"
+
+func TestNilPropertiesGet(t *testing.T) {
+	var p *Properties
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Get panicked: %v", r)
+		}
+	}()
+	v, ok := p.Get("missing")
+	if ok || v != "" {
+		t.Fatalf("got %q ok=%v", v, ok)
+	}
+}

--- a/properties.go
+++ b/properties.go
@@ -103,6 +103,9 @@ func (p *Properties) Load(buf []byte, enc Encoding) error {
 // Get returns the expanded value for the given key if exists.
 // Otherwise, ok is false.
 func (p *Properties) Get(key string) (value string, ok bool) {
+	if p == nil {
+		return "", false
+	}
 	v, ok := p.m[key]
 	if p.DisableExpansion {
 		return v, ok


### PR DESCRIPTION
```go
var p *properties.Properties
p.Get("x") // panic
```

Return `("", false)` instead.