### PR TITLE
fix: strip UTF-8 BOM when loading properties

### DIFF
--- a/bom_test.go
+++ b/bom_test.go
@@ -1,0 +1,28 @@
+package properties
+
+import "testing"
+
+func TestLoadUTF8BOM(t *testing.T) {
+	// Editors on Windows often prepend a UTF-8 BOM.
+	data := []byte("\xef\xbb\xbfa=1\nb=2\n")
+	p, err := Load(data, UTF8)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := p.GetString("a", ""); got != "1" {
+		t.Fatalf("a: got %q want 1 (keys=%v)", got, p.Keys())
+	}
+	if got := p.GetString("b", ""); got != "2" {
+		t.Fatalf("b: got %q want 2", got)
+	}
+}
+
+func TestLoadStringUTF8BOM(t *testing.T) {
+	p, err := LoadString("\ufefffoo=bar")
+	if err != nil {
+		t.Fatalf("LoadString: %v", err)
+	}
+	if got := p.GetString("foo", ""); got != "bar" {
+		t.Fatalf("foo: got %q want bar (keys=%v)", got, p.Keys())
+	}
+}

--- a/load.go
+++ b/load.go
@@ -5,6 +5,7 @@
 package properties
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -156,6 +157,10 @@ func (l *Loader) LoadURL(url string) (*Properties, error) {
 }
 
 func (l *Loader) loadBytes(buf []byte, enc Encoding) (*Properties, error) {
+	// Strip a leading UTF-8 BOM so Windows-edited property files load cleanly.
+	if enc == UTF8 || enc == utf8Default {
+		buf = bytes.TrimPrefix(buf, []byte{0xEF, 0xBB, 0xBF})
+	}
 	p, err := parse(convert(buf, enc))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
`.properties` files saved from some Windows editors start with a UTF-8 BOM. The first key was then stored as `"\ufeffa"` instead of `"a"`, so normal lookups failed.

Strip a leading BOM in `loadBytes` for UTF-8 encodings.

## Test plan
- [x] `go test -run TestLoad`
- [x] New tests for `Load` / `LoadString` with BOM-prefixed input