### PR TITLE
fix: reject empty filename in LoadFile

### DIFF
--- a/empty_file_test.go
+++ b/empty_file_test.go
@@ -1,0 +1,12 @@
+package properties
+
+import "testing"
+
+func TestLoadFileEmptyPath(t *testing.T) {
+	if _, err := LoadFile("  ", UTF8); err == nil {
+		t.Fatal("expected error")
+	}
+	if _, err := LoadFile("", UTF8); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/load.go
+++ b/load.go
@@ -195,6 +195,10 @@ func LoadMap(m map[string]string) *Properties {
 
 // LoadFile reads a file into a Properties struct.
 func LoadFile(filename string, enc Encoding) (*Properties, error) {
+	filename = strings.TrimSpace(filename)
+	if filename == "" {
+		return nil, fmt.Errorf("properties: empty filename")
+	}
 	l := &Loader{Encoding: enc}
 	return l.LoadAll([]string{filename})
 }


### PR DESCRIPTION
## What

`LoadFile` trims the path and errors when empty.

## Why

Blank config paths produced confusing OS open errors.

## Test

- `TestLoadFileEmptyPath`