### PR TITLE
Keep unknown escape sequences such as \\1

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -307,8 +307,9 @@ func (l *lexer) scanEscapeSequence() error {
 	case isEOF(r):
 		return fmt.Errorf("premature EOF")
 
-	// silently drop the escape character and append the rune as is
+	// Keep the backslash for unknown escapes so values like \1 round-trip.
 	default:
+		l.appendRune('\\')
 		l.appendRune(r)
 		return nil
 	}
@@ -386,7 +387,7 @@ func isEscape(r rune) bool {
 // isEscapedCharacter reports whether we are at one of the characters that need escaping.
 // The escape character has already been consumed.
 func isEscapedCharacter(r rune) bool {
-	return strings.ContainsRune(" :=fnrt", r)
+	return strings.ContainsRune(" :=\\fnrt", r)
 }
 
 // isWhitespace reports whether the rune is a whitespace character.

--- a/properties_test.go
+++ b/properties_test.go
@@ -64,9 +64,9 @@ var complexTests = [][]string{
 	{"key = v\\ralue", "key", "v\ralue"},
 	{"key = v\\talue", "key", "v\talue"},
 
-	// silently dropped escape character
-	{"k\\zey = value", "kzey", "value"},
-	{"key = v\\zalue", "key", "vzalue"},
+	// unknown escape: keep the backslash
+	{"k\\zey = value", "k\\zey", "value"},
+	{"key = v\\zalue", "key", "v\\zalue"},
 
 	// unicode literals
 	{"key\\u2318 = value", "key⌘", "value"},


### PR DESCRIPTION
Load dropped the backslash for any escape that was not a known character, so values like Postgres `log_line_prefix` `\\1` became `1` and could not round-trip.

Keep unknown sequences such as `\\1`. Treat `\\\\` as a real escape so a doubled backslash still decodes to a single `\\`.

Fixes #68

## Test
`go test . -count=1`
